### PR TITLE
Update badges and docs link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Valeri Karpov <valkar207@gmail.com>",
            "Kevin Yeh <kevinyeah@utexas.edu>"]
 
 description = "An experimental MongoDB driver written by MongoDB interns."
-repository = "https://github.com/mongodbinc-interns/mongo-rust-driver-prototype"
-documentation = "https://mongodbinc-interns.github.io/mongo-rust-driver-prototype/mongodb"
+repository = "https://github.com/mongodb-labs/mongo-rust-driver-prototype"
+documentation = "https://mongodb-labs.github.io/mongo-rust-driver-prototype/mongodb"
 readme = "README.md"
 keywords = ["mongo", "mongodb", "database", "bson", "nosql"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![Travis](https://travis-ci.org/mongodbinc-interns/mongo-rust-driver-prototype.svg)
+[![Travis](https://travis-ci.org/mongodb-labs/mongo-rust-driver-prototype.svg)](https://travis-ci.org/mongodb-labs/mongo-rust-driver-prototype)
+[![Crates.io](https://img.shields.io/crates/v/mongodb.svg)](https://crates.io/crates/mongodb)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 MongoDB Rust Driver Prototype
 =============================
@@ -68,4 +70,4 @@ fn main() {
 ```
 
 ## Documentation
-Documentation is built using Cargo. Generated documentation using ```cargo doc``` can be found under the _target/doc/_ folder.
+Documentation is built using Cargo. The latest documentation can be found [here](https://mongodb-labs.github.io/mongo-rust-driver-prototype/mongodb). Generated documentation using ```cargo doc``` can be found under the _target/doc/_ folder.


### PR DESCRIPTION
Fixes the documentation, repository, and Travis badge links under Cargo.toml and README.

Also adds crates.io and licensing badges.