### PR TITLE
Some changes to reflect Rust 1.4 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,39 @@
-[![Travis](https://travis-ci.org/mongodb-labs/mongo-rust-driver-prototype.svg)](https://travis-ci.org/mongodb-labs/mongo-rust-driver-prototype)
-[![Crates.io](https://img.shields.io/crates/v/mongodb.svg)](https://crates.io/crates/mongodb)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![Travis](https://travis-ci.org/mongodb-labs/mongo-rust-driver-prototype.svg)](https://travis-ci.org/mongodb-labs/mongo-rust-driver-prototype)[![Crates.io](https://img.shields.io/crates/v/mongodb.svg)](https://crates.io/crates/mongodb)[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 MongoDB Rust Driver Prototype
 =============================
 
-This branch contains active development on a new driver written for Rust 1.0.
+This branch contains active development on a new driver written for Rust 1.x.
 
 The API and implementation are currently subject to change at any time. You must not use this driver in production as it is still under development and is in no way supported by MongoDB Inc. We absolutely encourage you to experiment with it and provide us feedback on the API, design, and implementation. Bug reports and suggestions for improvements are welcomed, as are pull requests.
 
-## Installation
+Installation
+------------
 
 #### Dependencies
-- [Rust 1.0 with Cargo](http://rust-lang.org)
+
+-	[Rust 1.x with Cargo](http://rust-lang.org)
 
 #### Importing
-The 1.0 driver is available on crates.io. To use the MongoDB driver in your code, add the bson and mongodb packages to your ```Cargo.toml```:
+
+The 1.0 driver is available on crates.io. To use the MongoDB driver in your code, add the bson and mongodb packages to your `Cargo.toml`:
+
 ```
 [dependencies]
-bson = "0.1.3"
+bson = "0.1.4"
 mongodb = "0.1.0"
 ```
 
 Then, import the bson and driver libraries within your code.
+
 ```rust
 #[macro_use(bson, doc)]
 extern crate bson;
 extern crate mongodb;
 ```
 
-## Examples
+Examples
+--------
 
 Here's a basic example of driver usage:
 
@@ -69,5 +73,7 @@ fn main() {
 }
 ```
 
-## Documentation
-Documentation is built using Cargo. The latest documentation can be found [here](https://mongodb-labs.github.io/mongo-rust-driver-prototype/mongodb). Generated documentation using ```cargo doc``` can be found under the _target/doc/_ folder.
+Documentation
+-------------
+
+Documentation is built using Cargo. The latest documentation can be found [here](https://mongodb-labs.github.io/mongo-rust-driver-prototype/mongodb). Generated documentation using `cargo doc` can be found under the *target/doc/* folder.

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -16,7 +16,7 @@
 //!
 //! let mut cursor = coll.find(None, None).unwrap();
 //! for result in cursor {
-//!     let doc = result.ok().expect("Received network error during cursor operations.");
+//!     let doc = result.expect("Received network error during cursor operations.");
 //!     if let Some(&Bson::String(ref value)) = doc.get("spirit_animal") {
 //!         println!("My spirit animal is {}", value);
 //!     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,18 +12,18 @@
 //! #
 //! // Direct connection to a server. Will not look for other servers in the topology.
 //! let client = Client::connect("localhost", 27017)
-//!     .ok().expect("Failed to initialize client.");
+//!     .expect("Failed to initialize client.");
 //!
 //! // Connect to a complex server topology, such as a replica set
 //! // or sharded cluster, using a connection string uri.
 //! let client = Client::with_uri("mongodb://localhost:27017,localhost:27018/")
-//!     .ok().expect("Failed to initialize client.");
+//!     .expect("Failed to initialize client.");
 //!
 //! // Specify a read preference, and rely on the driver to find secondaries.
 //! let mut options = ClientOptions::new();
 //! options.read_preference = Some(ReadPreference::new(ReadMode::SecondaryPreferred, None));
 //! let client = Client::with_uri_and_options("mongodb://localhost:27017/", options)
-//!     .ok().expect("Failed to initialize client.");
+//!     .expect("Failed to initialize client.");
 //! ```
 //!
 //! ## Interacting with MongoDB Collections

--- a/tests/apm/mod.rs
+++ b/tests/apm/mod.rs
@@ -23,7 +23,7 @@ fn timed_query(_client: Client, command_result: &CommandResult) {
 
 #[test]
 fn command_duration() {
-    let mut client = Client::connect("localhost", 27017).ok().expect("damn it!");
+    let mut client = Client::connect("localhost", 27017).expect("damn it!");
     let db = client.db("test");
     let coll = db.collection("event_hooks");
     coll.drop().unwrap();

--- a/tests/client/client.rs
+++ b/tests/client/client.rs
@@ -6,14 +6,14 @@ use std::thread;
 #[test]
 fn database_names() {
     let client = Client::connect("localhost", 27018).unwrap();
-    let state_results = client.database_names().ok().expect("Failed to execute database_names.");
+    let state_results = client.database_names().expect("Failed to execute database_names.");
     for name in state_results {
         if name != "local" {
-            client.drop_database(&name[..]).ok().expect("Failed to drop database from server.");
+            client.drop_database(&name[..]).expect("Failed to drop database from server.");
         }
     }
 
-    let base_results = client.database_names().ok().expect("Failed to execute database_names.");
+    let base_results = client.database_names().expect("Failed to execute database_names.");
     assert_eq!(1, base_results.len());
     assert_eq!("local", base_results[0]);
 
@@ -21,12 +21,12 @@ fn database_names() {
     let db1 = client.db("new_db");
     let db2 = client.db("new_db_2");
     db1.collection("test1").insert_one(bson::Document::new(), None)
-        .ok().expect("Failed to insert placeholder document into collection");
+        .expect("Failed to insert placeholder document into collection");
     db2.collection("test2").insert_one(bson::Document::new(), None)
-        .ok().expect("Failed to insert placeholder document into collection");
+        .expect("Failed to insert placeholder document into collection");
 
     // Check new dbs
-    let results = client.database_names().ok().expect("Failed to execute database_names.");
+    let results = client.database_names().expect("Failed to execute database_names.");
     assert_eq!(3, results.len());
     assert!(results.contains(&"local".to_owned()));
     assert!(results.contains(&"new_db".to_owned()));
@@ -37,40 +37,40 @@ fn database_names() {
 #[test]
 fn is_master() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let res = client.is_master().ok().expect("Failed to execute is_master.");
+    let res = client.is_master().expect("Failed to execute is_master.");
     assert!(res);
 }
 
 #[test]
 fn is_sync() {
     let client = Client::connect("localhost", 27018).unwrap();
-    let state_results = client.database_names().ok().expect("Failed to execute database_names.");
+    let state_results = client.database_names().expect("Failed to execute database_names.");
     for name in state_results {
         if name != "local" {
-            client.drop_database(&name[..]).ok().expect("Failed to drop database from server.");
+            client.drop_database(&name[..]).expect("Failed to drop database from server.");
         }
     }
 
     let client1 = client.clone();
     let client2 = client.clone();
 
-    let base_results = client.database_names().ok().expect("Failed to execute database_names.");
+    let base_results = client.database_names().expect("Failed to execute database_names.");
     assert_eq!(1, base_results.len());
     assert_eq!("local", base_results[0]);
 
     let child1 = thread::spawn(move || {
         let db = client1.db("concurrent_db");
         db.collection("test1").insert_one(bson::Document::new(), None)
-            .ok().expect("Failed to insert placeholder document into collection");
-        let results = client1.database_names().ok().expect("Failed to execute database_names.");
+            .expect("Failed to insert placeholder document into collection");
+        let results = client1.database_names().expect("Failed to execute database_names.");
         assert!(results.contains(&"concurrent_db".to_owned()));
     });
 
     let child2 = thread::spawn(move || {
         let db = client2.db("concurrent_db_2");
         db.collection("test2").insert_one(bson::Document::new(), None)
-            .ok().expect("Failed to insert placeholder document into collection");
-        let results = client2.database_names().ok().expect("Failed to execute database_names.");
+            .expect("Failed to insert placeholder document into collection");
+        let results = client2.database_names().expect("Failed to execute database_names.");
         assert!(results.contains(&"concurrent_db_2".to_owned()));
     });
 
@@ -78,7 +78,7 @@ fn is_sync() {
     let _ = child2.join();
 
     // Check new dbs
-    let results = client.database_names().ok().expect("Failed to execute database_names.");
+    let results = client.database_names().expect("Failed to execute database_names.");
     assert_eq!(3, results.len());
     assert!(results.contains(&"local".to_owned()));
     assert!(results.contains(&"concurrent_db".to_owned()));

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -11,7 +11,7 @@ fn find_sorted() {
     let db = client.db("test");
     let coll = db.collection("find_sorted");
 
-    coll.drop().ok().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop database");
 
     // Insert document
     let doc1 = doc! { "title" => "Jaws" };
@@ -19,14 +19,14 @@ fn find_sorted() {
     let doc3 = doc! { "title" => "Dobby" };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone()], None)
-        .ok().expect("Failed to insert documents.");
+        .expect("Failed to insert documents.");
 
     // Find document
     let mut opts = FindOptions::new();
     opts.sort = Some(doc! { "title" => 1 });
 
-    let mut cursor = coll.find(None, Some(opts)).ok().expect("Failed to execute find command.");
-    let results = cursor.next_n(3).ok().expect("Failed to retrieve documents.");
+    let mut cursor = coll.find(None, Some(opts)).expect("Failed to execute find command.");
+    let results = cursor.next_n(3).expect("Failed to retrieve documents.");
 
     // Assert expected titles of documents
     match results[0].get("title") {
@@ -54,14 +54,14 @@ fn find_and_insert() {
     let db = client.db("test");
     let coll = db.collection("find_and_insert");
 
-    coll.drop().ok().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop database");
 
     // Insert document
     let doc = doc! { "title" => "Jaws" };
-    coll.insert_one(doc, None).ok().expect("Failed to insert document");
+    coll.insert_one(doc, None).expect("Failed to insert document");
 
     // Find document
-    let mut cursor = coll.find(None, None).ok().expect("Failed to execute find command.");
+    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
     let result = match cursor.next() {
         Some(Ok(res)) => res,
         Some(Err(_)) => panic!("Received error from 'cursor.next()'."),
@@ -83,14 +83,14 @@ fn find_and_insert_one() {
     let db = client.db("test");
     let coll = db.collection("find_and_insert");
 
-    coll.drop().ok().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop database");
 
     // Insert document
     let doc = doc! { "title" => "Jaws" };
-    coll.insert_one(doc, None).ok().expect("Failed to insert document");
+    coll.insert_one(doc, None).expect("Failed to insert document");
 
     // Find single document
-    let result = coll.find_one(None, None).ok().expect("Failed to execute find command.");
+    let result = coll.find_one(None, None).expect("Failed to execute find command.");
     assert!(result.is_some());
 
     // Assert expected title of document
@@ -106,18 +106,18 @@ fn find_one_and_delete() {
     let db = client.db("test");
     let coll = db.collection("find_one_and_delete");
 
-    coll.drop().ok().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
     let doc2 = doc! { "title" => "Back to the Future" };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone()], None)
-        .ok().expect("Failed to insert documents.");
+        .expect("Failed to insert documents.");
 
     // Find and Delete document
     let result = coll.find_one_and_delete(doc2.clone(), None)
-        .ok().expect("Failed to execute find_one_and_delete command.");
+        .expect("Failed to execute find_one_and_delete command.");
 
     match result.unwrap().get("title") {
         Some(&Bson::String(ref title)) => assert_eq!("Back to the Future", title),
@@ -125,7 +125,7 @@ fn find_one_and_delete() {
     }
 
     // Validate state of collection
-    let mut cursor = coll.find(None, None).ok().expect("Failed to execute find command.");
+    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
     let result = match cursor.next() {
         Some(Ok(res)) => res,
         Some(Err(_)) => panic!("Received error from 'cursor.next()'."),
@@ -146,7 +146,7 @@ fn find_one_and_replace() {
     let db = client.db("test");
     let coll = db.collection("find_one_and_replace");
 
-    coll.drop().ok().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
@@ -154,11 +154,11 @@ fn find_one_and_replace() {
     let doc3 = doc! { "title" => "12 Angry Men" };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone()], None)
-        .ok().expect("Failed to insert documents into collection.");
+        .expect("Failed to insert documents into collection.");
 
     // Replace single document
     let result = coll.find_one_and_replace(doc2.clone(), doc3.clone(), None)
-        .ok().expect("Failed to execute find_one_and_replace command.");
+        .expect("Failed to execute find_one_and_replace command.");
 
     match result.unwrap().get("title") {
         Some(&Bson::String(ref title)) => assert_eq!("Back to the Future", title),
@@ -166,8 +166,8 @@ fn find_one_and_replace() {
     }
 
     // Validate state of collection
-    let mut cursor = coll.find(None, None).ok().expect("Failed to execute find command.");
-    let results = cursor.next_n(3).ok().expect("Failed to get next 3 from cursor.");
+    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
+    let results = cursor.next_n(3).expect("Failed to get next 3 from cursor.");
     assert_eq!(3, results.len());
 
     // Assert expected title of documents
@@ -188,7 +188,7 @@ fn find_one_and_replace() {
     let mut opts = FindOneAndUpdateOptions::new();
     opts.return_document = ReturnDocument::After;
     let result = coll.find_one_and_replace(doc3.clone(), doc2.clone(), Some(opts))
-        .ok().expect("Failed to execute find_one_and_replace command.");
+        .expect("Failed to execute find_one_and_replace command.");
 
     match result.unwrap().get("title") {
         Some(&Bson::String(ref title)) => assert_eq!("Back to the Future", title),
@@ -202,7 +202,7 @@ fn find_one_and_update() {
     let db = client.db("test");
     let coll = db.collection("find_one_and_update");
 
-    coll.drop().ok().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
@@ -210,13 +210,13 @@ fn find_one_and_update() {
     let doc3 = doc! { "title" => "12 Angry Men" };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone()], None)
-        .ok().expect("Failed to insert documents into collection.");
+        .expect("Failed to insert documents into collection.");
 
     // Update single document
     let update = doc! { "$set" => { "director" => "Robert Zemeckis" } };
 
     let result = coll.find_one_and_update(doc2.clone(), update, None)
-        .ok().expect("Failed to execute find_one_and_update command.");
+        .expect("Failed to execute find_one_and_update command.");
 
     match result.unwrap().get("title") {
         Some(&Bson::String(ref title)) => assert_eq!("Back to the Future", title),
@@ -224,8 +224,8 @@ fn find_one_and_update() {
     }
 
     // Validate state of collection
-    let mut cursor = coll.find(None, None).ok().expect("Failed to execute find command.");
-    let results = cursor.next_n(3).ok().expect("Failed to get next 3 from cursor.");
+    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
+    let results = cursor.next_n(3).expect("Failed to get next 3 from cursor.");
     assert_eq!(3, results.len());
 
     // Assert director attributes
@@ -243,7 +243,7 @@ fn aggregate() {
     let db = client.db("test");
     let coll = db.collection("aggregate");
 
-    coll.drop().ok().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "tags" => ["a", "b", "c"] };
@@ -251,7 +251,7 @@ fn aggregate() {
     let doc3 = doc! { "tags" => ["d", "e", "f"] };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone()], None)
-        .ok().expect("Failed to execute insert_many command.");
+        .expect("Failed to execute insert_many command.");
 
     // Build aggregation pipeline to unwind tag arrays and group distinct tags
     let project = doc! { "$project" => { "tags" => 1 } };
@@ -260,9 +260,9 @@ fn aggregate() {
 
     // Aggregate
     let mut cursor = coll.aggregate(vec![project, unwind, group], None)
-        .ok().expect("Failed to execute aggregate command.");
+        .expect("Failed to execute aggregate command.");
 
-    let results = cursor.next_n(10).ok().expect("Failed to get next 10 from cursor.");
+    let results = cursor.next_n(10).expect("Failed to get next 10 from cursor.");
     assert_eq!(6, results.len());
 
     // Grab ids from aggregated docs
@@ -289,7 +289,7 @@ fn count() {
     let db = client.db("test");
     let coll = db.collection("count");
 
-    coll.drop().ok().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
@@ -300,18 +300,18 @@ fn count() {
         vec.push(doc2.clone());
     }
 
-    coll.insert_many(vec, None).ok().expect("Failed to insert documents.");
-    let count_doc1 = coll.count(Some(doc1), None).ok().expect("Failed to execute count.");
+    coll.insert_many(vec, None).expect("Failed to insert documents.");
+    let count_doc1 = coll.count(Some(doc1), None).expect("Failed to execute count.");
     assert_eq!(1, count_doc1);
 
-    let count_doc2 = coll.count(Some(doc2), None).ok().expect("Failed to execute count.");
+    let count_doc2 = coll.count(Some(doc2), None).expect("Failed to execute count.");
     assert_eq!(10, count_doc2);
 
-    let count_all = coll.count(None, None).ok().expect("Failed to execute count.");
+    let count_all = coll.count(None, None).expect("Failed to execute count.");
     assert_eq!(11, count_all);
 
     let no_doc = doc! { "title" => "Houdini" };
-    let count_none = coll.count(Some(no_doc), None).ok().expect("Failed to execute count.");
+    let count_none = coll.count(Some(no_doc), None).expect("Failed to execute count.");
     assert_eq!(0, count_none);
 }
 
@@ -321,8 +321,8 @@ fn distinct_none() {
     let db = client.db("test");
     let coll = db.collection("distinct_none");
 
-    coll.drop().ok().expect("Failed to drop database");
-    let distinct_titles = coll.distinct("title", None, None).ok().expect("Failed to execute 'distinct'.");
+    coll.drop().expect("Failed to drop database");
+    let distinct_titles = coll.distinct("title", None, None).expect("Failed to execute 'distinct'.");
     assert_eq!(0, distinct_titles.len());
 }
 
@@ -332,11 +332,11 @@ fn distinct_one() {
     let db = client.db("test");
     let coll = db.collection("distinct_none");
 
-    coll.drop().ok().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop database");
     let doc2 = doc! { "title" => "Back to the Future" };
-    coll.insert_one(doc2, None).ok().expect("Failed to insert document.");
+    coll.insert_one(doc2, None).expect("Failed to insert document.");
 
-    let distinct_titles = coll.distinct("title", None, None).ok().expect("Failed to execute 'distinct'.");
+    let distinct_titles = coll.distinct("title", None, None).expect("Failed to execute 'distinct'.");
     assert_eq!(1, distinct_titles.len());
 }
 
@@ -346,7 +346,7 @@ fn distinct() {
     let db = client.db("test");
     let coll = db.collection("distinct");
 
-    coll.drop().ok().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws",
@@ -365,10 +365,10 @@ fn distinct() {
         vec.push(doc3.clone());
     }
 
-    coll.insert_many(vec, None).ok().expect("Failed to insert documents.");
+    coll.insert_many(vec, None).expect("Failed to insert documents.");
 
     // Distinct titles over all documents
-    let distinct_titles = coll.distinct("title", None, None).ok().expect("Failed to execute 'distinct'.");
+    let distinct_titles = coll.distinct("title", None, None).expect("Failed to execute 'distinct'.");
     assert_eq!(3, distinct_titles.len());
 
     let titles: Vec<_> = distinct_titles.iter().filter_map(|bson| match bson {
@@ -384,7 +384,7 @@ fn distinct() {
     // Distinct titles over documents with certain director
     let filter = doc! { "director" => "MB" };
     let distinct_titles = coll.distinct("title", Some(filter), None)
-        .ok().expect("Failed to execute 'distinct'.");
+        .expect("Failed to execute 'distinct'.");
 
     assert_eq!(2, distinct_titles.len());
 
@@ -404,17 +404,17 @@ fn insert_many() {
     let db = client.db("test");
     let coll = db.collection("insert_many");
 
-    coll.drop().ok().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
     let doc2 = doc! { "title" => "Back to the Future" };
 
-    coll.insert_many(vec![doc1, doc2], None).ok().expect("Failed to insert documents.");
+    coll.insert_many(vec![doc1, doc2], None).expect("Failed to insert documents.");
 
     // Find documents
-    let mut cursor = coll.find(None, None).ok().expect("Failed to execute find command.");
-    let results = cursor.next_n(2).ok().expect("Failed to get next 2 from cursor.");
+    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
+    let results = cursor.next_n(2).expect("Failed to get next 2 from cursor.");
     assert_eq!(2, results.len());
 
     // Assert expected title of documents
@@ -434,18 +434,18 @@ fn delete_one() {
     let db = client.db("test");
     let coll = db.collection("delete_one");
 
-    coll.drop().ok().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
     let doc2 = doc! { "title" => "Back to the Future" };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone()], None)
-        .ok().expect("Failed to insert documents.");
+        .expect("Failed to insert documents.");
 
     // Delete document
-    coll.delete_one(doc2.clone(), None).ok().expect("Failed to delete document.");
-    let mut cursor = coll.find(None, None).ok().expect("Failed to execute find command.");
+    coll.delete_one(doc2.clone(), None).expect("Failed to delete document.");
+    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
     let result = match cursor.next() {
         Some(Ok(res)) => res,
         Some(Err(_)) => panic!("Received error from 'cursor.next()'."),
@@ -466,18 +466,18 @@ fn delete_many() {
     let db = client.db("test");
     let coll = db.collection("delete_many");
 
-    coll.drop().ok().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
     let doc2 = doc! { "title" => "Back to the Future" };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc2.clone()], None)
-        .ok().expect("Failed to insert documents into collection.");
+        .expect("Failed to insert documents into collection.");
 
     // Delete document
-    coll.delete_many(doc2.clone(), None).ok().expect("Failed to delete documents.");
-    let mut cursor = coll.find(None, None).ok().expect("Failed to execute find command.");
+    coll.delete_many(doc2.clone(), None).expect("Failed to delete documents.");
+    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
     let result = match cursor.next() {
         Some(Ok(res)) => res,
         Some(Err(_)) => panic!("Received error from 'cursor.next()'."),
@@ -498,7 +498,7 @@ fn replace_one() {
     let db = client.db("test");
     let coll = db.collection("replace_one");
 
-    coll.drop().ok().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
@@ -506,12 +506,12 @@ fn replace_one() {
     let doc3 = doc! { "title" => "12 Angry Men" };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone()], None)
-        .ok().expect("Failed to insert documents into collection.");
+        .expect("Failed to insert documents into collection.");
 
     // Replace single document
-    coll.replace_one(doc2.clone(), doc3.clone(), None).ok().expect("Failed to replace document.");
-    let mut cursor = coll.find(None, None).ok().expect("Failed to execute find command.");
-    let results = cursor.next_n(3).ok().expect("Failed to get next 3 from cursor.");
+    coll.replace_one(doc2.clone(), doc3.clone(), None).expect("Failed to replace document.");
+    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
+    let results = cursor.next_n(3).expect("Failed to get next 3 from cursor.");
     assert_eq!(3, results.len());
 
     // Assert expected title of documents
@@ -535,7 +535,7 @@ fn update_one() {
     let db = client.db("test");
     let coll = db.collection("update_one");
 
-    coll.drop().ok().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
@@ -543,15 +543,15 @@ fn update_one() {
     let doc3 = doc! { "title" => "12 Angry Men" };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone()], None)
-        .ok().expect("Failed to insert documents into collection.");
+        .expect("Failed to insert documents into collection.");
 
     // Update single document
     let update = doc! { "$set" => { "director" => "Robert Zemeckis" } };
 
-    coll.update_one(doc2.clone(), update, None).ok().expect("Failed to update document.");
+    coll.update_one(doc2.clone(), update, None).expect("Failed to update document.");
 
-    let mut cursor = coll.find(None, None).ok().expect("Failed to execute find command.");
-    let results = cursor.next_n(3).ok().expect("Failed to get next 3 from cursor.");
+    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
+    let results = cursor.next_n(3).expect("Failed to get next 3 from cursor.");
     assert_eq!(3, results.len());
 
     // Assert director attributes
@@ -569,7 +569,7 @@ fn update_many() {
     let db = client.db("test");
     let coll = db.collection("update_many");
 
-    coll.drop().ok().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
@@ -577,15 +577,15 @@ fn update_many() {
     let doc3 = doc! { "title" => "12 Angry Men" };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone(), doc2.clone()], None)
-        .ok().expect("Failed to insert documents into collection.");
+        .expect("Failed to insert documents into collection.");
 
     // Update single document
     let update = doc! { "$set" => { "director" => "Robert Zemeckis" } };
 
-    coll.update_many(doc2.clone(), update, None).ok().expect("Failed to update documents.");
+    coll.update_many(doc2.clone(), update, None).expect("Failed to update documents.");
 
-    let mut cursor = coll.find(None, None).ok().expect("Failed to execute find command.");
-    let results = cursor.next_n(4).ok().expect("Failed to get next 4 from cursor.");
+    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
+    let results = cursor.next_n(4).expect("Failed to get next 4 from cursor.");
     assert_eq!(4, results.len());
 
     // Assert director attributes
@@ -609,7 +609,7 @@ fn create_list_drop_indexes() {
     let db = client.db("test");
     let coll = db.collection("create_list_drop_indexes");
 
-    coll.drop().ok().expect("Failed to drop database.");
+    coll.drop().expect("Failed to drop database.");
 
     let mut opts1 = IndexOptions::new();
     opts1.name = Some("nid".to_owned());
@@ -686,7 +686,7 @@ fn drop_all_indexes() {
     let db = client.db("test");
     let coll = db.collection("drop_all_indexes");
 
-    coll.drop().ok().expect("Failed to drop database.");
+    coll.drop().expect("Failed to drop database.");
 
     let mut opts1 = IndexOptions::new();
     opts1.name = Some("nid".to_owned());

--- a/tests/client/crud_spec/framework.rs
+++ b/tests/client/crud_spec/framework.rs
@@ -13,7 +13,7 @@ macro_rules! run_aggregate_test {
                 assert!(eq::bson_eq(&bson, b2));
             }
 
-            assert!(!cursor.has_next().ok().expect("Failed to execute 'has_next()' on cursor"));
+            assert!(!cursor.has_next().expect("Failed to execute 'has_next()' on cursor"));
         }
 
         check_coll!($db, $coll, $outcome.collection);
@@ -125,7 +125,7 @@ macro_rules! run_find_test {
             assert!(eq::bson_eq(&bson, &Bson::Document(cursor.next().unwrap().unwrap())));
         }
 
-        assert!(!cursor.has_next().ok().expect("Failed to execute 'has_next()' on cursor"));
+        assert!(!cursor.has_next().expect("Failed to execute 'has_next()' on cursor"));
         check_coll!($db, $coll, $outcome.collection);
     }};
 }
@@ -311,7 +311,7 @@ macro_rules! check_coll {
                                 &Bson::Document(cursor.next().unwrap().unwrap())));
         }
 
-        assert!(!cursor.has_next().ok().expect("Failed to execute 'has_next()' on cursor"));
+        assert!(!cursor.has_next().expect("Failed to execute 'has_next()' on cursor"));
 
         $coll.drop().unwrap();
     }};

--- a/tests/client/cursor.rs
+++ b/tests/client/cursor.rs
@@ -12,7 +12,7 @@ fn cursor_features() {
     let db = client.db("test");
     let coll = db.collection("cursor_test");
 
-    coll.drop().ok().expect("Failed to drop database.");
+    coll.drop().expect("Failed to drop database.");
 
     let docs = (0..10).map(|i| {
         doc! { "foo" => (i as i64) }
@@ -32,7 +32,7 @@ fn cursor_features() {
         Err(s) => panic!("{}", s)
     };
 
-    let batch = cursor.next_batch().ok().expect("Failed to get next batch from cursor.");
+    let batch = cursor.next_batch().expect("Failed to get next batch from cursor.");
 
     assert_eq!(batch.len(), 3 as usize);
 
@@ -54,11 +54,11 @@ fn cursor_features() {
         _ => panic!("Wrong value returned from Cursor#next")
     };
 
-    assert!(cursor.has_next().ok().expect("Failed to execute 'has_next()'."));
-    let vec = cursor.next_n(20).ok().expect("Failed to get next 20 results.");;
+    assert!(cursor.has_next().expect("Failed to execute 'has_next()'."));
+    let vec = cursor.next_n(20).expect("Failed to get next 20 results.");;
 
     assert_eq!(vec.len(), 6 as usize);
-    assert!(!cursor.has_next().ok().expect("Failed to execute 'has_next()'."));
+    assert!(!cursor.has_next().expect("Failed to execute 'has_next()'."));
 
     for i in 0..vec.len() {
         match vec[i].get("foo") {

--- a/tests/client/db.rs
+++ b/tests/client/db.rs
@@ -16,7 +16,7 @@ fn create_collection() {
 
     // Check for namespaces
     let mut cursor = db.list_collections_with_batch_size(None, 1)
-        .ok().expect("Failed to execute list_collections command.");;
+        .expect("Failed to execute list_collections command.");;
 
     let results = cursor.next_n(5).unwrap();
     assert_eq!(3, results.len());
@@ -40,17 +40,17 @@ fn list_collections() {
     let client = Client::connect("localhost", 27017).unwrap();
     let db = client.db("list_collections");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    db.drop_database().expect("Failed to drop database");
 
     // Build collections
     db.collection("test").insert_one(bson::Document::new(), None)
-        .ok().expect("Failed to insert placeholder document into collection");
+        .expect("Failed to insert placeholder document into collection");
     db.collection("test2").insert_one(bson::Document::new(), None)
-        .ok().expect("Failed to insert placeholder document into collection");
+        .expect("Failed to insert placeholder document into collection");
 
     // Check for namespaces
     let mut cursor = db.list_collections_with_batch_size(None, 1)
-        .ok().expect("Failed to execute list_collections command.");;
+        .expect("Failed to execute list_collections command.");;
 
     let results = cursor.next_n(5).unwrap();
     assert_eq!(3, results.len());

--- a/tests/client/gridfs.rs
+++ b/tests/client/gridfs.rs
@@ -17,8 +17,8 @@ fn init_gridfs(name: &str) -> (Store, Collection, Collection) {
 
     let fsfiles = db.collection("fs.files");
     let fschunks = db.collection("fs.chunks");
-    fsfiles.drop().ok().expect("Failed to drop files collection.");
-    fschunks.drop().ok().expect("Failed to drop chunks collection.");
+    fsfiles.drop().expect("Failed to drop files collection.");
+    fschunks.drop().expect("Failed to drop chunks collection.");
     (fs, fsfiles, fschunks)
 }
 
@@ -56,7 +56,7 @@ fn put_get() {
     // Check chunks
     let mut cursor = fschunks.find(Some(doc!{"files_id" => (id.clone())}), Some(opts)).unwrap();
 
-    let chunks = cursor.next_batch().ok().expect("Failed to get next batch");
+    let chunks = cursor.next_batch().expect("Failed to get next batch");
     assert_eq!(3, chunks.len());
 
     for i in 0..3 {
@@ -82,7 +82,7 @@ fn put_get() {
     let mut cursor = fschunks.list_indexes().unwrap();
     let results = cursor.next_n(10).unwrap();
     assert_eq!(2, results.len());
-    
+
     // Get
     let mut dest = Vec::with_capacity(src_len);
     unsafe { dest.set_len(src_len) };

--- a/tests/json/crud/reader.rs
+++ b/tests/json/crud/reader.rs
@@ -125,9 +125,9 @@ pub trait SuiteContainer: Sized {
 
 impl SuiteContainer for Json {
     fn from_file(path: &str) -> Result<Json, String> {
-        let mut file = File::open(path).ok().expect(&format!("Unable to open file: {}", path));
+        let mut file = File::open(path).expect(&format!("Unable to open file: {}", path));
 
-        Ok(Json::from_reader(&mut file).ok().expect(&format!("Invalid JSON file: {}", path)))
+        Ok(Json::from_reader(&mut file).expect(&format!("Invalid JSON file: {}", path)))
     }
 
     fn get_suite(&self) -> Result<Suite, String> {

--- a/tests/json/crud/reader.rs
+++ b/tests/json/crud/reader.rs
@@ -118,7 +118,7 @@ fn get_tests(object: &Object) -> Result<Vec<Test>, String> {
     Ok(tests)
 }
 
-pub trait SuiteContainer {
+pub trait SuiteContainer: Sized {
     fn from_file(path: &str) -> Result<Self, String>;
     fn get_suite(&self) -> Result<Suite, String>;
 }

--- a/tests/json/mod.rs
+++ b/tests/json/mod.rs
@@ -12,6 +12,6 @@ pub trait FromJson {
     fn from_json(object: &Object) -> Self;
 }
 
-pub trait FromJsonResult {
+pub trait FromJsonResult: Sized {
     fn from_json(object: &Object) -> Result<Self, String>;
 }

--- a/tests/json/sdam/reader.rs
+++ b/tests/json/sdam/reader.rs
@@ -51,7 +51,7 @@ fn get_phases(object: &Object) -> Result<Vec<Phase>, String> {
     Ok(phases)
 }
 
-pub trait SuiteContainer {
+pub trait SuiteContainer: Sized {
     fn from_file(path: &str) -> Result<Self, String>;
     fn get_suite(&self) -> Result<Suite, String>;
 }

--- a/tests/json/sdam/reader.rs
+++ b/tests/json/sdam/reader.rs
@@ -58,9 +58,9 @@ pub trait SuiteContainer: Sized {
 
 impl SuiteContainer for Json {
     fn from_file(path: &str) -> Result<Json, String> {
-        let mut file = File::open(path).ok().expect(&format!("Unable to open file: {}", path));
+        let mut file = File::open(path).expect(&format!("Unable to open file: {}", path));
 
-        Ok(Json::from_reader(&mut file).ok().expect(&format!("Invalid JSON file: {}", path)))
+        Ok(Json::from_reader(&mut file).expect(&format!("Invalid JSON file: {}", path)))
     }
 
     fn get_suite(&self) -> Result<Suite, String> {

--- a/tests/json/server_selection/reader.rs
+++ b/tests/json/server_selection/reader.rs
@@ -42,8 +42,8 @@ pub trait SuiteContainer: Sized {
 
 impl SuiteContainer for Json {
     fn from_file(path: &str) -> Result<Json, String> {
-        let mut file = File::open(path).ok().expect(&format!("Unable to open file: {}", path));
-        Ok(Json::from_reader(&mut file).ok().expect(&format!("Invalid JSON file: {}", path)))
+        let mut file = File::open(path).expect(&format!("Unable to open file: {}", path));
+        Ok(Json::from_reader(&mut file).expect(&format!("Invalid JSON file: {}", path)))
     }
 
     fn get_suite(&self) -> Result<Suite, String> {

--- a/tests/json/server_selection/reader.rs
+++ b/tests/json/server_selection/reader.rs
@@ -35,7 +35,7 @@ fn get_server_array(arr: &Vec<Json>) -> Result<Vec<Server>, String> {
     Ok(servers)
 }
 
-pub trait SuiteContainer {
+pub trait SuiteContainer: Sized {
     fn from_file(path: &str) -> Result<Self, String>;
     fn get_suite(&self) -> Result<Suite, String>;
 }

--- a/tests/json/server_selection/server.rs
+++ b/tests/json/server_selection/server.rs
@@ -23,7 +23,7 @@ impl Server {
                               Some(&Json::U64(v)) => v as i64,
                               "server must have an average rtt.");
 
-        let mut tags = BTreeMap::new();        
+        let mut tags = BTreeMap::new();
         let json_doc = val_or_err!(object.get("tags"),
                                    Some(&Json::Object(ref obj)) => obj.clone(),
                                    "server must have tags.");
@@ -37,11 +37,11 @@ impl Server {
 
         let stype = val_or_err!(object.get("type"),
                                 Some(&Json::String(ref s)) => ServerType::from_str(s)
-                                .ok().expect("Failed to parse server type"),
+                                .expect("Failed to parse server type"),
                                 "server must have a type.");
 
         Ok(Server {
-            host: connstring::parse_host(&address).ok().expect("Failed to parse host."),
+            host: connstring::parse_host(&address).expect("Failed to parse host."),
             rtt: rtt,
             tags: tags,
             stype: stype,


### PR DESCRIPTION
Version 1.4 of Rust just came out today, and there are a few changes that affect the driver. First, the use of `Self` as a type in a trait now produces a warning if the trait does not also implement `Sized`. Additionally, the `.expect()` method (essentially `unwrap()` with a custom error message) has been added to `Result`, so there's no need to convert them to `Option` using `.ok()` beforehand.

Since the change with `.expect()` would not work on earlier versions of the compiler, it might make sense to put these changes in a separate `1.4` branch rather than merging with 1.0, which would make them available for people who opt to use newer version of Rust.