### PR TITLE
Fixed deprecation warnings introduced by Rust 1.6

### DIFF
--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -18,6 +18,7 @@ use std::i64;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::thread;
+use std::time::Duration;
 use time;
 
 use self::server::{Server, ServerDescription, ServerType};
@@ -741,12 +742,12 @@ impl Topology {
                         return Err(err)
                     }
                     // Otherwise, sleep for a little while.
-                    thread::sleep_ms(500);
+                    thread::sleep(Duration::from_millis(500));
                 },
             }
-        }        
+        }
     }
-    
+
     /// Returns a server stream for read operations.
     pub fn acquire_stream(&self, read_preference: ReadPreference) -> Result<(PooledStream, bool, bool)> {
         self.acquire_stream_private(Some(read_preference), false)

--- a/src/topology/monitor.rs
+++ b/src/topology/monitor.rs
@@ -15,6 +15,7 @@ use wire_protocol::flags::OpQueryFlags;
 use std::collections::BTreeMap;
 use std::sync::{Arc, Condvar, Mutex, RwLock};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
 
 use time;
 
@@ -348,8 +349,8 @@ impl Monitor {
                                                   Ordering::SeqCst);
             }
 
-            let frequency = self.heartbeat_frequency_ms.load(Ordering::SeqCst) as u32;
-            guard = self.condvar.wait_timeout_ms(guard, frequency).unwrap().0;
+            let frequency = self.heartbeat_frequency_ms.load(Ordering::SeqCst) as u64;
+            guard = self.condvar.wait_timeout(guard, Duration::from_millis(frequency)).unwrap().0;
         }
     }
 }


### PR DESCRIPTION
This PR fixes 2 deprecation warnings introduced in rust 1.6 :
[thread::sleep_ms](http://doc.rust-lang.org/stable/std/thread/fn.sleep_ms.html) and [Condvar::wait_timeout_ms](http://doc.rust-lang.org/stable/std/sync/struct.Condvar.html#method.wait_timeout_ms)

Those deprecations are translated into warnings during compile time :
```
src/topology/monitor.rs:352:34: 352:67 warning: use of deprecated item: replaced by `std::sync::Condvar::wait_timeout`, #[warn(deprecated)] on by default
src/topology/monitor.rs:352             guard = self.condvar.wait_timeout_ms(guard, frequency).unwrap().0;
                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/topology/mod.rs:744:21: 744:37 warning: use of deprecated item: replaced by `std::thread::sleep`, #[warn(deprecated)] on by default
src/topology/mod.rs:744                     thread::sleep_ms(500);
                                            ^~~~~~~~~~~~~~~~
```