### PR TITLE
Use `setVersion` to detect stale topology updates

### DIFF
--- a/src/topology/monitor.rs
+++ b/src/topology/monitor.rs
@@ -53,6 +53,7 @@ pub struct IsMasterResult {
     pub election_id: Option<oid::ObjectId>,
     pub primary: Option<Host>,
     pub hidden: bool,
+    pub set_version: Option<i64>,
 }
 
 /// Monitors and updates server and topology information.
@@ -112,6 +113,7 @@ impl IsMasterResult {
             election_id: None,
             primary: None,
             hidden: false,
+            set_version: None,
         };
 
         if let Some(&Bson::Boolean(b)) = doc.get("ismaster") {
@@ -181,6 +183,10 @@ impl IsMasterResult {
 
         if let Some(&Bson::Boolean(ref h)) = doc.get("hidden") {
             result.hidden = *h;
+        }
+
+        if let Some(&Bson::I64(v)) = doc.get("setVersion") {
+            result.set_version = Some(v);
         }
 
         if let Some(&Bson::Document(ref doc)) = doc.get("tags") {

--- a/src/topology/server.rs
+++ b/src/topology/server.rs
@@ -71,6 +71,8 @@ pub struct ServerDescription {
     pub election_id: Option<oid::ObjectId>,
     /// The server's opinion of who the primary is.
     pub primary: Option<Host>,
+    /// The current replica set version number.
+    pub set_version: Option<i64>,
 }
 
 /// Holds status and connection information about a single server.
@@ -119,6 +121,7 @@ impl ServerDescription {
             set_name: String::new(),
             election_id: None,
             primary: None,
+            set_version: None,
         }
     }
 
@@ -128,6 +131,8 @@ impl ServerDescription {
             self.set_err(OperationError("ismaster returned a not-ok response.".to_owned()));
             return;
         }
+
+        println!("{:#?}", ismaster);
 
         self.min_wire_version = ismaster.min_wire_version;
         self.max_wire_version = ismaster.max_wire_version;
@@ -139,6 +144,7 @@ impl ServerDescription {
         self.set_name = ismaster.set_name;
         self.election_id = ismaster.election_id;
         self.primary = ismaster.primary;
+        self.set_version = ismaster.set_version;
         self.round_trip_time = match self.round_trip_time {
             Some(old_rtt) => {
                 // (rtt / div) + (old_rtt * (div-1)/div)

--- a/src/topology/server.rs
+++ b/src/topology/server.rs
@@ -132,8 +132,6 @@ impl ServerDescription {
             return;
         }
 
-        println!("{:#?}", ismaster);
-
         self.min_wire_version = ismaster.min_wire_version;
         self.max_wire_version = ismaster.max_wire_version;
         self.me = ismaster.me;


### PR DESCRIPTION
I added a `set_version` field to `Server` and `IsMaster` result as well as a `max_set_version` field to `TopologyDescription` to be used in the same way as `election_id` and `max_election_id` to detect stale updates to the topology. This fixes #153.

The SDAM spec tests still fail after this due to a later test in the suite failing; I double checked that this update didn't cause the later failure by temporarily removing the test this PR fixes and running the test suite against HEAD, and the later test still fails (I'll create an issue about it once I have a chance to look into it).