### PR TITLE
Hidden replica set members should be RsOther

### DIFF
--- a/src/topology/server.rs
+++ b/src/topology/server.rs
@@ -157,7 +157,7 @@ impl ServerDescription {
             ServerType::Mongos
         } else if ismaster.is_master && !set_name_empty {
             ServerType::RSPrimary
-        } else if ismaster.is_secondary && !set_name_empty {
+        } else if ismaster.is_secondary && !set_name_empty && !ismaster.hidden {
             ServerType::RSSecondary
         } else if ismaster.arbiter_only && !set_name_empty {
             ServerType::RSArbiter


### PR DESCRIPTION
According to [the spec](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#type), hidden replica set members should be of type RSOther. [One of the tests](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/tests/rs/rsother_discovered.json) had been updated to test this.