### PR TITLE
Fix update rs with primary from member

### DIFF
--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -645,13 +645,13 @@ impl TopologyDescription {
 
         if self.set_name != description.set_name {
             self.servers.remove(&host);
-            return;
         }
 
         if let Some(me) = description.me {
             if host != me {
                 self.servers.remove(&host);
             }
+            return;
         }
 
         self.check_if_has_primary();


### PR DESCRIPTION
According to [the spec](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#user-content-updaterswithprimaryfrommember), the return statement should be in the second if, not the first. This fixes the failure in the test `stepdown_change_set_name.json`.