### PR TITLE
Fix GridFS race condition

### DIFF
--- a/src/gridfs/file.rs
+++ b/src/gridfs/file.rs
@@ -649,7 +649,7 @@ impl CachedChunk {
         CachedChunk {
             n: n,
             data: Vec::new(),
-            err: Some(Error::DefaultError(String::from("Chunk has not yet been inititalied"))),
+            err: Some(Error::DefaultError(String::from("Chunk has not yet been initialized"))),
         }
     }
 }

--- a/src/gridfs/file.rs
+++ b/src/gridfs/file.rs
@@ -325,7 +325,7 @@ impl File {
                 match result {
                     Ok(Some(doc)) => match doc.get("data") {
                         Some(&Bson::Binary(_, ref buf)) => {
-                            cache.data = buf.clone()
+                            cache.data = buf.clone();
                             cache.err = None;
                         },
                         _ => cache.err = Some(OperationError("Chunk contained no data.".to_owned())),

--- a/src/gridfs/file.rs
+++ b/src/gridfs/file.rs
@@ -324,7 +324,10 @@ impl File {
 
                 match result {
                     Ok(Some(doc)) => match doc.get("data") {
-                        Some(&Bson::Binary(_, ref buf)) => cache.data = buf.clone(),
+                        Some(&Bson::Binary(_, ref buf)) => {
+                            cache.data = buf.clone()
+                            cache.err = None;
+                        },
                         _ => cache.err = Some(OperationError("Chunk contained no data.".to_owned())),
                     },
                     Ok(None) => cache.err = Some(OperationError("Chunk not found.".to_owned())),
@@ -646,7 +649,7 @@ impl CachedChunk {
         CachedChunk {
             n: n,
             data: Vec::new(),
-            err: None,
+            err: Some(Error::DefaultError(String::from("Chunk has not yet been inititalied"))),
         }
     }
 }


### PR DESCRIPTION
The GridFS cache [get initialized with an empty chunk](https://github.com/saghm/mongo-rust-driver-prototype/blob/fix-gridfs-race-condition/src/gridfs/file.rs#L338) but the chunk itself is initialized asynchronously, which leads to a race condition when the cache is checked [here](https://github.com/saghm/mongo-rust-driver-prototype/blob/fix-gridfs-race-condition/src/gridfs/file.rs#L292) on subsequent calls to `get_chunk`. This is fixed by initializing each `CachedChunk` with a placeholder error that gets removed when the chunk is initialized.