### PR TITLE
Add `db.version()` function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rand = "0.3.14"
 rust-crypto = "0.2.31"
 rustc-serialize = "0.3.19"
 scan_fmt = "0.1.0"
+semver = "0.5.0"
 separator = "0.3.1"
 textnonce = { version = "0.4.1", default-features = false }
 time = "0.1.35"

--- a/src/command_type.rs
+++ b/src/command_type.rs
@@ -4,6 +4,7 @@
 #[derive(PartialEq, Eq, Clone)]
 pub enum CommandType {
     Aggregate,
+    BuildInfo,
     Count,
     CreateCollection,
     CreateIndexes,
@@ -37,6 +38,7 @@ impl CommandType {
     pub fn to_str(&self) -> &str {
         match *self {
             CommandType::Aggregate => "aggregate",
+            CommandType::BuildInfo => "buildinfo",
             CommandType::Count => "count",
             CommandType::CreateCollection => "create_collection",
             CommandType::CreateIndexes => "create_indexes",
@@ -87,6 +89,7 @@ impl CommandType {
             CommandType::UpdateMany |
             CommandType::UpdateOne => true,
             CommandType::Aggregate |
+            CommandType::BuildInfo |
             CommandType::Count |
             CommandType::Distinct |
             CommandType::Find |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ extern crate rand;
 extern crate rustc_serialize;
 #[macro_use]
 extern crate scan_fmt;
+extern crate semver;
 extern crate separator;
 extern crate textnonce;
 extern crate time;

--- a/tests/client/db.rs
+++ b/tests/client/db.rs
@@ -171,6 +171,6 @@ fn create_and_get_users() {
 #[test]
 fn get_version() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("create_and_get_users");
+    let db = client.db("get_version");
     let version = db.version().unwrap();
 }

--- a/tests/client/db.rs
+++ b/tests/client/db.rs
@@ -167,3 +167,10 @@ fn create_and_get_users() {
         _ => panic!("User isn't named 'val' but should be"),
     };
 }
+
+#[test]
+fn get_version() {
+    let client = Client::connect("localhost", 27017).unwrap();
+    let db = client.db("create_and_get_users");
+    let version = db.version().unwrap();
+}


### PR DESCRIPTION
:wave:

Adding a db function to grab the MongoDB semantic version. As promised in #169, this can be used to remove the version feature used in tests and check the version at runtime.