### PR TITLE
Use db.version() for test switch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
     - 3.0.12/bin/mongod --fork --nopreallocj --dbpath ./data/db --syslog --port 27017
     - 3.0.12/bin/mongod --fork --nopreallocj --dbpath ./data/test --syslog --port 27018
     - cargo build --verbose
-    - cargo test --features "mongodb_3_0" --verbose
+    - cargo test --verbose
     - killall mongod
     - 3.2.10/bin/mongod --fork --nopreallocj --dbpath ./data/db2 --syslog --port 27017
     - 3.2.10/bin/mongod --fork --nopreallocj --dbpath ./data/test2 --syslog --port 27018

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,3 @@ bufstream = "0.1.1"
 
 [dev-dependencies]
 nalgebra = "0.10.1"
-
-[features]
-default = []
-mongodb_3_0 = []

--- a/tests/client/db.rs
+++ b/tests/client/db.rs
@@ -20,11 +20,13 @@ fn create_collection() {
 
     let results = cursor.next_n(5).unwrap();
 
-    let v3_0 = cfg!(feature = "mongodb_3_0");
-    let result_size = if v3_0 { 3 } else { 2 };
+    let db_version = db.version().unwrap();
+    let v3_1 = db_version.major <= 3 && db_version.minor <= 1;
+
+    let result_size = if v3_1 { 3 } else { 2 };
     assert_eq!(result_size, results.len());
 
-    if v3_0 {
+    if v3_1 {
         match results[0].get("name") {
             Some(&Bson::String(ref name)) => assert_eq!("system.indexes", name),
             _ => panic!("Expected BSON string!"),
@@ -62,11 +64,13 @@ fn list_collections() {
 
     let results = cursor.next_n(5).unwrap();
 
-    let v3_0 = cfg!(feature = "mongodb_3_0");
-    let result_size = if v3_0 { 3 } else { 2 };
+    let db_version = db.version().unwrap();
+    let v3_1 = db_version.major <= 3 && db_version.minor <= 1;
+
+    let result_size = if v3_1 { 3 } else { 2 };
     assert_eq!(result_size, results.len());
 
-    if v3_0 {
+    if v3_1 {
         match results[0].get("name") {
             Some(&Bson::String(ref name)) => assert_eq!("system.indexes", name),
             _ => panic!("Expected BSON string!"),
@@ -172,5 +176,5 @@ fn create_and_get_users() {
 fn get_version() {
     let client = Client::connect("localhost", 27017).unwrap();
     let db = client.db("get_version");
-    let version = db.version().unwrap();
+    let _ = db.version().unwrap();
 }


### PR DESCRIPTION
👋 

This removes the test-specific feature flag in favor of using `db.version()`, completing our PR narrative for merging versioned tests. #169 #171