### PR TITLE
Parallelize test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
     - 3.0.12/bin/mongod --fork --nopreallocj --dbpath ./data/db --syslog --port 27017
     - 3.0.12/bin/mongod --fork --nopreallocj --dbpath ./data/test --syslog --port 27018
     - cargo build --verbose
-    - cargo test --features "mongodb_3_0" --verbose
+    - cargo test --verbose
     - killall mongod
     - 3.2.10/bin/mongod --fork --nopreallocj --dbpath ./data/db2 --syslog --port 27017
     - 3.2.10/bin/mongod --fork --nopreallocj --dbpath ./data/test2 --syslog --port 27018

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ before_install:
     - tar xvf mongodb-linux-x86_64-3.2.10.tgz
     - mv mongodb-linux-x86_64-3.2.10 3.2.10
 
-env:
-    - RUST_TEST_THREADS=1
-
 script:
     - mkdir -p ./data/db ./data/test ./data/db2 ./data/test2
     - 3.0.12/bin/mongod --fork --nopreallocj --dbpath ./data/db --syslog --port 27017

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,10 @@ before_install:
     - mv mongodb-linux-x86_64-3.2.10 3.2.10
 
 script:
-    - mkdir -p ./data/db ./data/test ./data/db2 ./data/test2
+    - mkdir -p ./data/db ./data/db2
     - 3.0.12/bin/mongod --fork --nopreallocj --dbpath ./data/db --syslog --port 27017
-    - 3.0.12/bin/mongod --fork --nopreallocj --dbpath ./data/test --syslog --port 27018
     - cargo build --verbose
     - cargo test --verbose
     - killall mongod
     - 3.2.10/bin/mongod --fork --nopreallocj --dbpath ./data/db2 --syslog --port 27017
-    - 3.2.10/bin/mongod --fork --nopreallocj --dbpath ./data/test2 --syslog --port 27018
     - cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,3 @@ bufstream = "0.1.1"
 
 [dev-dependencies]
 nalgebra = "0.10.1"
-
-[features]
-default = []
-mongodb_3_0 = []

--- a/tests/apm/mod.rs
+++ b/tests/apm/mod.rs
@@ -56,14 +56,21 @@ fn read_first_non_monitor_line(file: &mut BufReader<&File>, line: &mut String) {
 fn logging() {
     let _ = fs::remove_file("test_apm_log.txt");
 
+    // Reset State
+    let client = Client::connect("localhost", 27017).expect("Failed to connect to localhost:27017");
+    let coll = db.collection("logging");
+    coll.drop().unwrap();
+
+    // Start logging
     let client_options = ClientOptions::with_log_file("test_apm_log.txt");
     let client = Client::connect_with_options("localhost", 27017, client_options).unwrap();
 
     let db = client.db("test-apm-mod");
+
     db.create_collection("logging", None).unwrap();
     let coll = db.collection("logging");
     coll.drop().unwrap();
-
+    
     let doc1 = doc! { "_id" => 1 };
     let doc2 = doc! { "_id" => 2 };
     let doc3 = doc! { "_id" => 3 };

--- a/tests/apm/mod.rs
+++ b/tests/apm/mod.rs
@@ -27,8 +27,8 @@ fn timed_query(_client: Client, command_result: &CommandResult) {
 #[test]
 fn command_duration() {
     let mut client = Client::connect("localhost", 27017).expect("damn it!");
-    let db = client.db("test");
-    let coll = db.collection("event_hooks");
+    let db = client.db("test_apm_mod");
+    let coll = db.collection("command_duration");
     coll.drop().unwrap();
 
     let docs = (1..4).map(|i| doc! { "_id" => i, "x" => (rand::random::<u8>() as u32) }).collect();
@@ -54,12 +54,12 @@ fn read_first_non_monitor_line(file: &mut BufReader<&File>, line: &mut String) {
 
 #[test]
 fn logging() {
-    let _ = fs::remove_file("test_log.txt");
+    let _ = fs::remove_file("test_apm_log.txt");
 
-    let client_options = ClientOptions::with_log_file("test_log.txt");
+    let client_options = ClientOptions::with_log_file("test_apm_log.txt");
     let client = Client::connect_with_options("localhost", 27017, client_options).unwrap();
 
-    let db = client.db("test");
+    let db = client.db("test_apm_mod");
     db.create_collection("logging", None).unwrap();
     let coll = db.collection("logging");
     coll.drop().unwrap();
@@ -78,7 +78,7 @@ fn logging() {
 
     coll.find(Some(filter), None).unwrap();
 
-    let f = File::open("test_log.txt").unwrap();
+    let f = File::open("test_apm_log.txt").unwrap();
     let mut file = BufReader::new(&f);
     let mut line = String::new();
 
@@ -88,7 +88,7 @@ fn logging() {
                 capped: false, auto_index_id: true, flags: 1 }\n",
                &line);
 
-    // Create Collection completed
+    // Create collection completed
     line.clear();
     read_first_non_monitor_line(&mut file, &mut line);
     assert!(line.starts_with("COMMAND.create_collection 127.0.0.1:27017 COMPLETED: { ok: 1 } ("));
@@ -163,5 +163,5 @@ fn logging() {
 
     coll.drop().unwrap();
 
-    fs::remove_file("test_log.txt").unwrap();
+    fs::remove_file("test_apm_log.txt").unwrap();
 }

--- a/tests/apm/mod.rs
+++ b/tests/apm/mod.rs
@@ -27,7 +27,7 @@ fn timed_query(_client: Client, command_result: &CommandResult) {
 #[test]
 fn command_duration() {
     let mut client = Client::connect("localhost", 27017).expect("damn it!");
-    let db = client.db("test_apm_mod");
+    let db = client.db("test-apm-mod");
     let coll = db.collection("command_duration");
     coll.drop().unwrap();
 
@@ -59,7 +59,7 @@ fn logging() {
     let client_options = ClientOptions::with_log_file("test_apm_log.txt");
     let client = Client::connect_with_options("localhost", 27017, client_options).unwrap();
 
-    let db = client.db("test_apm_mod");
+    let db = client.db("test-apm-mod");
     db.create_collection("logging", None).unwrap();
     let coll = db.collection("logging");
     coll.drop().unwrap();

--- a/tests/apm/mod.rs
+++ b/tests/apm/mod.rs
@@ -57,18 +57,18 @@ fn logging() {
     let _ = fs::remove_file("test_apm_log.txt");
 
     // Reset State
-    let client = Client::connect("localhost", 27017).expect("Failed to connect to localhost:27017");
-    let coll = db.collection("logging");
-    coll.drop().unwrap();
+    let reset_client = Client::connect("localhost", 27017).expect("Failed to connect to localhost:27017");
+    let reset_db = reset_client.db("test-apm-mod");
+    let reset_coll = reset_db.collection("logging");
+    reset_coll.drop().unwrap();
 
     // Start logging
     let client_options = ClientOptions::with_log_file("test_apm_log.txt");
     let client = Client::connect_with_options("localhost", 27017, client_options).unwrap();
 
     let db = client.db("test-apm-mod");
-
-    db.create_collection("logging", None).unwrap();
     let coll = db.collection("logging");
+    db.create_collection("logging", None).unwrap();
     coll.drop().unwrap();
     
     let doc1 = doc! { "_id" => 1 };

--- a/tests/apm/mod.rs
+++ b/tests/apm/mod.rs
@@ -104,7 +104,7 @@ fn logging() {
     line.clear();
     read_first_non_monitor_line(&mut file, &mut line);
     assert!(line.starts_with("COMMAND.drop_collection 127.0.0.1:27017 COMPLETED: { ns: \
-                              \"test.logging\", nIndexesWas: 1, ok: 1 } ("));
+                              \"test-apm-mod.logging\", nIndexesWas: 1, ok: 1 } ("));
     assert!(line.ends_with(" ns)\n"));
 
     // First insert started
@@ -157,7 +157,7 @@ fn logging() {
     line.clear();
     read_first_non_monitor_line(&mut file, &mut line);
     assert!(line.starts_with("COMMAND.find 127.0.0.1:27017 COMPLETED: { cursor: { id: 0, ns: \
-                              \"test.logging\", firstBatch: [{ _id: 2 }, { _id: 3 }] }, ok: 1 } \
+                              \"test-apm-mod.logging\", firstBatch: [{ _id: 2 }, { _id: 3 }] }, ok: 1 } \
                               ("));
     assert!(line.ends_with(" ns)\n"));
 

--- a/tests/auth/mod.rs
+++ b/tests/auth/mod.rs
@@ -6,7 +6,7 @@ use mongodb::error::Error::OperationError;
 #[test]
 fn invalid_user() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test_auth_mod_invalid_user");
+    let db = client.db("test-auth-mod-invalid_user");
     let _ = db.drop_all_users(None).unwrap();
     let doc = doc! { "connectionStatus" => 1};
     let before = db.command(doc.clone(), CommandType::Suppressed, None).unwrap();
@@ -21,7 +21,7 @@ fn invalid_user() {
         _ => panic!("Invalid array of authenticatedUsers for initial connectionStatus command"),
     };
 
-    match db.auth("test_auth_invalid_user", "some_password") {
+    match db.auth("test-auth-invalid_user", "some_password") {
         Err(OperationError(_)) => (),
         Err(_) => {
             panic!("Expected OperationError for invalid authentication, but got some other error \
@@ -47,7 +47,7 @@ fn invalid_user() {
 #[test]
 fn invalid_password() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test_auth_mod_invalid_password");
+    let db = client.db("test-auth-mod-invalid_password");
     let _ = db.drop_all_users(None).unwrap();
     let doc = doc! { "connectionStatus" => 1};
     let before = db.command(doc.clone(), CommandType::Suppressed, None).unwrap();
@@ -89,7 +89,7 @@ fn invalid_password() {
 #[test]
 fn successful_login() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test_auth_mod_successful_login");
+    let db = client.db("test-auth-mod-successful_login");
     let _ = db.drop_all_users(None).unwrap();
     let doc = doc! { "connectionStatus" => 1};
     let before = db.command(doc.clone(), CommandType::Suppressed, None).unwrap();

--- a/tests/auth/mod.rs
+++ b/tests/auth/mod.rs
@@ -3,11 +3,24 @@ use mongodb::{CommandType, Client, ThreadedClient};
 use mongodb::db::ThreadedDatabase;
 use mongodb::error::Error::OperationError;
 
+fn doc_vec_find(vec: &Vec<Bson>, key: &str, val: &str) -> Option<Bson> {
+    vec.iter()
+       .cloned()
+       .find(|ref bdoc| match bdoc {
+           &&Bson::Document(ref doc) => match doc.get(key) {
+               Some(&Bson::String(ref s)) => s == val,
+               _ => false
+           },
+           _ => false,
+       })
+       .map(|ref bson| bson.to_owned())
+}
+
 #[test]
 fn invalid_user() {
     let client = Client::connect("localhost", 27017).unwrap();
     let db = client.db("test-auth-mod-invalid_user");
-    let _ = db.drop_all_users(None).unwrap();
+    let _ = db.drop_user("test-auth-mod-invalid_user-saghm", None);
     let doc = doc! { "connectionStatus" => 1};
     let before = db.command(doc.clone(), CommandType::Suppressed, None).unwrap();
 
@@ -17,11 +30,11 @@ fn invalid_user() {
     };
 
     match info.get("authenticatedUsers") {
-        Some(&Bson::Array(ref vec)) => assert!(vec.is_empty()),
+        Some(&Bson::Array(ref vec)) => assert!(doc_vec_find(&vec, "user", "test-auth-mod-invalid_user-saghm").is_none()),
         _ => panic!("Invalid array of authenticatedUsers for initial connectionStatus command"),
     };
 
-    match db.auth("test-auth-invalid_user", "some_password") {
+    match db.auth("test-auth-mod-invalid_user-saghm", "some_password") {
         Err(OperationError(_)) => (),
         Err(_) => {
             panic!("Expected OperationError for invalid authentication, but got some other error \
@@ -36,19 +49,18 @@ fn invalid_user() {
         Some(&Bson::Document(ref doc)) => doc.clone(),
         _ => panic!("Invalid response for subsequent connectionStatus command"),
     };
-
+        
     match info.get("authenticatedUsers") {
-        Some(&Bson::Array(ref vec)) => assert!(vec.is_empty()),
-        _ => panic!("Invalid array of authenticatedUsers for subsequent connectionStatus command"),
+        Some(&Bson::Array(ref vec)) => assert!(doc_vec_find(&vec, "user", "test-auth-mod-invalid_user-saghm").is_none()),
+        _ => panic!("Invalid array of authenticatedUsers for initial connectionStatus command"),
     };
 }
-
 
 #[test]
 fn invalid_password() {
     let client = Client::connect("localhost", 27017).unwrap();
     let db = client.db("test-auth-mod-invalid_password");
-    let _ = db.drop_all_users(None).unwrap();
+    let _ = db.drop_user("test-auth-mod-invalid_password-saghm", None);
     let doc = doc! { "connectionStatus" => 1};
     let before = db.command(doc.clone(), CommandType::Suppressed, None).unwrap();
 
@@ -58,13 +70,13 @@ fn invalid_password() {
     };
 
     match info.get("authenticatedUsers") {
-        Some(&Bson::Array(ref vec)) => assert!(vec.is_empty()),
+        Some(&Bson::Array(ref vec)) => assert!(doc_vec_find(&vec, "user", "test-auth-mod-invalid_password-saghm").is_none()),
         _ => panic!("Invalid array of authenticatedUsers for initial connectionStatus command"),
     };
 
-    db.create_user("saghm", "such_secure_password", None).unwrap();
+    db.create_user("test-auth-mod-invalid_password-saghm", "such_secure_password", None).unwrap();
 
-    match db.auth("saghm", "wrong_password") {
+    match db.auth("test-auth-mod-invalid_password-saghm", "wrong_password") {
         Err(OperationError(_)) => (),
         Err(_) => {
             panic!("Expected OperationError for invalid authentication, but got some other error \
@@ -81,7 +93,7 @@ fn invalid_password() {
     };
 
     match info.get("authenticatedUsers") {
-        Some(&Bson::Array(ref vec)) => assert!(vec.is_empty()),
+        Some(&Bson::Array(ref vec)) => assert!(doc_vec_find(&vec, "user", "test-auth-mod-invalid_password-saghm").is_none()),
         _ => panic!("Invalid array of authenticatedUsers for subsequent connectionStatus command"),
     };
 }
@@ -90,7 +102,7 @@ fn invalid_password() {
 fn successful_login() {
     let client = Client::connect("localhost", 27017).unwrap();
     let db = client.db("test-auth-mod-successful_login");
-    let _ = db.drop_all_users(None).unwrap();
+    let _ = db.drop_user("test-auth-mod-successful_login-saghm", None);
     let doc = doc! { "connectionStatus" => 1};
     let before = db.command(doc.clone(), CommandType::Suppressed, None).unwrap();
 
@@ -100,12 +112,12 @@ fn successful_login() {
     };
 
     match info.get("authenticatedUsers") {
-        Some(&Bson::Array(ref vec)) => assert!(vec.is_empty()),
+        Some(&Bson::Array(ref vec)) => assert!(doc_vec_find(&vec, "user", "test-auth-mod-successful_login-saghm").is_none()),
         _ => panic!("Invalid array of authenticatedUsers for initial connectionStatus command"),
     };
 
-    db.create_user("saghm", "such_secure_password", None).unwrap();
-    db.auth("saghm", "such_secure_password").unwrap();
+    db.create_user("test-auth-mod-successful_login-saghm", "such_secure_password", None).unwrap();
+    db.auth("test-auth-mod-successful_login-saghm", "such_secure_password").unwrap();
 
     let after = db.command(doc, CommandType::Suppressed, None).unwrap();
 
@@ -119,15 +131,15 @@ fn successful_login() {
         _ => panic!("Invalid array of authenticatedUsers for subsequent connectionStatus command"),
     };
 
-    assert_eq!(authed_users.len(), 1);
+    let bson_user = doc_vec_find(&authed_users, "user", "test-auth-mod-successful_login-saghm").unwrap();
 
-    let user = match authed_users[0] {
+    let user = match bson_user {
         Bson::Document(ref doc) => doc.clone(),
         _ => panic!("Invalid auth'd user in subsequent connectionStatus response"),
     };
 
     match user.get("user") {
-        Some(&Bson::String(ref s)) => assert_eq!(s, "saghm"),
+        Some(&Bson::String(ref s)) => assert_eq!(s, "test-auth-mod-successful_login-saghm"),
         _ => panic!("Invalid `user` field of auth'd user"),
     };
 

--- a/tests/auth/mod.rs
+++ b/tests/auth/mod.rs
@@ -6,7 +6,7 @@ use mongodb::error::Error::OperationError;
 #[test]
 fn invalid_user() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("auth");
+    let db = client.db("test_auth_mod_invalid_user");
     let _ = db.drop_all_users(None).unwrap();
     let doc = doc! { "connectionStatus" => 1};
     let before = db.command(doc.clone(), CommandType::Suppressed, None).unwrap();
@@ -21,7 +21,7 @@ fn invalid_user() {
         _ => panic!("Invalid array of authenticatedUsers for initial connectionStatus command"),
     };
 
-    match db.auth("invalid_user", "some_password") {
+    match db.auth("test_auth_invalid_user", "some_password") {
         Err(OperationError(_)) => (),
         Err(_) => {
             panic!("Expected OperationError for invalid authentication, but got some other error \
@@ -47,7 +47,7 @@ fn invalid_user() {
 #[test]
 fn invalid_password() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("auth");
+    let db = client.db("test_auth_mod_invalid_password");
     let _ = db.drop_all_users(None).unwrap();
     let doc = doc! { "connectionStatus" => 1};
     let before = db.command(doc.clone(), CommandType::Suppressed, None).unwrap();
@@ -89,7 +89,7 @@ fn invalid_password() {
 #[test]
 fn successful_login() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("auth");
+    let db = client.db("test_auth_mod_successful_login");
     let _ = db.drop_all_users(None).unwrap();
     let doc = doc! { "connectionStatus" => 1};
     let before = db.command(doc.clone(), CommandType::Suppressed, None).unwrap();

--- a/tests/auth/mod.rs
+++ b/tests/auth/mod.rs
@@ -132,7 +132,7 @@ fn successful_login() {
     };
 
     match user.get("db") {
-        Some(&Bson::String(ref s)) => assert_eq!(s, "auth"),
+        Some(&Bson::String(ref s)) => assert_eq!(s, "test-auth-mod-successful_login"),
         _ => panic!("Invalid `db` field of auth'd user"),
     };
 }

--- a/tests/client/bulk.rs
+++ b/tests/client/bulk.rs
@@ -6,9 +6,8 @@ use mongodb::db::ThreadedDatabase;
 #[test]
 fn bulk_ordered_insert_only() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-bulk");
     let coll = db.collection("bulk_ordered_insert_only");
-
     coll.drop().unwrap();
 
     let models = (1..5)
@@ -47,7 +46,7 @@ fn bulk_ordered_insert_only() {
 #[test]
 fn bulk_unordered_insert_only() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-bulk");
     let coll = db.collection("bulk_unordered_insert_only");
 
     coll.drop().unwrap();
@@ -148,9 +147,8 @@ fn bulk_ordered_mix() {
     ];
 
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-bulk");
     let coll = db.collection("bulk_ordered_mix");
-
     coll.drop().unwrap();
 
     let result = coll.bulk_write(models, true);

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -8,10 +8,10 @@ use mongodb::coll::options::{FindOptions, FindOneAndUpdateOptions, IndexModel, I
 #[test]
 fn find_sorted() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("find_sorted");
 
-    coll.drop().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop collection");
 
     // Insert document
     let doc1 = doc! { "title" => "Jaws" };
@@ -51,10 +51,10 @@ fn find_sorted() {
 #[test]
 fn find_and_insert() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("find_and_insert");
 
-    coll.drop().expect("Failed to drop database");
+    coll.drop().expect("Failed to drop collection");
 
     // Insert document
     let doc = doc! { "title" => "Jaws" };
@@ -80,7 +80,7 @@ fn find_and_insert() {
 #[test]
 fn find_and_insert_one() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("find_and_insert");
 
     coll.drop().expect("Failed to drop database");
@@ -103,7 +103,7 @@ fn find_and_insert_one() {
 #[test]
 fn find_one_and_delete() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("find_one_and_delete");
 
     coll.drop().expect("Failed to drop database");
@@ -143,7 +143,7 @@ fn find_one_and_delete() {
 #[test]
 fn find_one_and_replace() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("find_one_and_replace");
 
     coll.drop().expect("Failed to drop database");
@@ -199,7 +199,7 @@ fn find_one_and_replace() {
 #[test]
 fn find_one_and_update() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("find_one_and_update");
 
     coll.drop().expect("Failed to drop database");
@@ -240,7 +240,7 @@ fn find_one_and_update() {
 #[test]
 fn aggregate() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("aggregate");
 
     coll.drop().expect("Failed to drop database");
@@ -288,7 +288,7 @@ fn aggregate() {
 #[test]
 fn count() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("count");
 
     coll.drop().expect("Failed to drop database");
@@ -320,7 +320,7 @@ fn count() {
 #[test]
 fn distinct_none() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("distinct_none");
 
     coll.drop().expect("Failed to drop database");
@@ -332,7 +332,7 @@ fn distinct_none() {
 #[test]
 fn distinct_one() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("distinct_none");
 
     coll.drop().expect("Failed to drop database");
@@ -347,7 +347,7 @@ fn distinct_one() {
 #[test]
 fn distinct() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("distinct");
 
     coll.drop().expect("Failed to drop database");
@@ -410,7 +410,7 @@ fn distinct() {
 #[test]
 fn insert_many() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("insert_many");
 
     coll.drop().expect("Failed to drop database");
@@ -440,7 +440,7 @@ fn insert_many() {
 #[test]
 fn delete_one() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("delete_one");
 
     coll.drop().expect("Failed to drop database");
@@ -472,7 +472,7 @@ fn delete_one() {
 #[test]
 fn delete_many() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("delete_many");
 
     coll.drop().expect("Failed to drop database");
@@ -504,7 +504,7 @@ fn delete_many() {
 #[test]
 fn replace_one() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("replace_one");
 
     coll.drop().expect("Failed to drop database");
@@ -541,7 +541,7 @@ fn replace_one() {
 #[test]
 fn update_one() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("update_one");
 
     coll.drop().expect("Failed to drop database");
@@ -575,7 +575,7 @@ fn update_one() {
 #[test]
 fn update_many() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("update_many");
 
     coll.drop().expect("Failed to drop database");
@@ -616,7 +616,7 @@ fn update_many() {
 #[test]
 fn create_list_drop_indexes() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("create_list_drop_indexes");
 
     coll.drop().expect("Failed to drop database.");
@@ -693,7 +693,7 @@ fn create_list_drop_indexes() {
 #[test]
 fn drop_all_indexes() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-coll");
     let coll = db.collection("drop_all_indexes");
 
     coll.drop().expect("Failed to drop database.");

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -333,7 +333,7 @@ fn distinct_none() {
 fn distinct_one() {
     let client = Client::connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
-    let coll = db.collection("distinct_none");
+    let coll = db.collection("distinct_one");
 
     coll.drop().expect("Failed to drop database");
     let doc2 = doc! { "title" => "Back to the Future" };

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -81,7 +81,7 @@ fn find_and_insert() {
 fn find_and_insert_one() {
     let client = Client::connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
-    let coll = db.collection("find_and_insert");
+    let coll = db.collection("find_and_insert_one");
 
     coll.drop().expect("Failed to drop database");
 

--- a/tests/client/cursor.rs
+++ b/tests/client/cursor.rs
@@ -9,10 +9,10 @@ use mongodb::wire_protocol::flags::OpQueryFlags;
 #[test]
 fn cursor_features() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
+    let db = client.db("test-client-cursor");
     let coll = db.collection("cursor_test");
 
-    coll.drop().expect("Failed to drop database.");
+    coll.drop().expect("Failed to drop collection.");
 
     let docs = (0..10)
         .map(|i| {

--- a/tests/client/cursor.rs
+++ b/tests/client/cursor.rs
@@ -26,7 +26,7 @@ fn cursor_features() {
     let flags = OpQueryFlags::no_flags();
 
     let result = Cursor::query(client.clone(),
-                               "test.cursor_test".to_owned(),
+                               "test-client-cursor.cursor_test".to_owned(),
                                3,
                                flags,
                                0,

--- a/tests/client/db.rs
+++ b/tests/client/db.rs
@@ -20,11 +20,13 @@ fn create_collection() {
 
     let results = cursor.next_n(5).unwrap();
 
-    let v3_0 = cfg!(feature = "mongodb_3_0");
-    let result_size = if v3_0 { 3 } else { 2 };
+    let db_version = db.version().unwrap();
+    let v3_1 = db_version.major <= 3 && db_version.minor <= 1;
+
+    let result_size = if v3_1 { 3 } else { 2 };
     assert_eq!(result_size, results.len());
 
-    if v3_0 {
+    if v3_1 {
         match results[0].get("name") {
             Some(&Bson::String(ref name)) => assert_eq!("system.indexes", name),
             _ => panic!("Expected BSON string!"),
@@ -62,11 +64,13 @@ fn list_collections() {
 
     let results = cursor.next_n(5).unwrap();
 
-    let v3_0 = cfg!(feature = "mongodb_3_0");
-    let result_size = if v3_0 { 3 } else { 2 };
+    let db_version = db.version().unwrap();
+    let v3_1 = db_version.major <= 3 && db_version.minor <= 1;
+
+    let result_size = if v3_1 { 3 } else { 2 };
     assert_eq!(result_size, results.len());
 
-    if v3_0 {
+    if v3_1 {
         match results[0].get("name") {
             Some(&Bson::String(ref name)) => assert_eq!("system.indexes", name),
             _ => panic!("Expected BSON string!"),
@@ -172,5 +176,5 @@ fn create_and_get_users() {
 fn get_version() {
     let client = Client::connect("localhost", 27017).unwrap();
     let db = client.db("get_version");
-    let version = db.version().unwrap();
+    let _ = db.version().unwrap();
 }

--- a/tests/client/db.rs
+++ b/tests/client/db.rs
@@ -7,7 +7,7 @@ use mongodb::db::roles::{AllDatabaseRole, SingleDatabaseRole, Role};
 #[test]
 fn create_collection() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("create_collection");
+    let db = client.db("test-client-db-create_collection");
     db.drop_database().unwrap();
 
     // Build collections
@@ -46,7 +46,7 @@ fn create_collection() {
 #[test]
 fn list_collections() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("list_collections");
+    let db = client.db("test-client-db-list_collections");
 
     db.drop_database().expect("Failed to drop database");
 
@@ -91,7 +91,7 @@ fn list_collections() {
 #[test]
 fn create_and_get_users() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("create_and_get_users");
+    let db = client.db("test-client-db-create_and_get_users");
     db.drop_database().unwrap();
     db.drop_all_users(None).unwrap();
 
@@ -175,6 +175,6 @@ fn create_and_get_users() {
 #[test]
 fn get_version() {
     let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("get_version");
+    let db = client.db("test-client-db-get_version");
     let _ = db.version().unwrap();
 }

--- a/tests/client/db.rs
+++ b/tests/client/db.rs
@@ -33,12 +33,15 @@ fn create_collection() {
         }
     }
 
+    let db_1 = if v3_1 { "test1" } else { "test2" };
+    let db_2 = if v3_1 { "test2" } else { "test1" };
+    
     match results[result_size - 2].get("name") {
-        Some(&Bson::String(ref name)) => assert_eq!("test1", name),
+        Some(&Bson::String(ref name)) => assert_eq!(db_1, name),
         _ => panic!("Expected BSON string!"),
     }
     match results[result_size - 1].get("name") {
-        Some(&Bson::String(ref name)) => assert_eq!("test2", name),
+        Some(&Bson::String(ref name)) => assert_eq!(db_2, name),
         _ => panic!("Expected BSON string!"),
     }
 }
@@ -77,13 +80,16 @@ fn list_collections() {
         };
     }
 
+    let db_1 = if v3_1 { "test" } else { "test2" };
+    let db_2 = if v3_1 { "test2" } else { "test" };
+    
     match results[result_size - 2].get("name") {
-        Some(&Bson::String(ref name)) => assert_eq!("test", name),
+        Some(&Bson::String(ref name)) => assert_eq!(db_1, name),
         _ => panic!("Expected BSON string!"),
     };
 
     match results[result_size - 1].get("name") {
-        Some(&Bson::String(ref name)) => assert_eq!("test2", name),
+        Some(&Bson::String(ref name)) => assert_eq!(db_2, name),
         _ => panic!("Expected BSON string!"),
     }
 }

--- a/tests/client/db.rs
+++ b/tests/client/db.rs
@@ -122,7 +122,7 @@ fn create_and_get_users() {
     let user = db.get_user("saghm", None).unwrap();
 
     match user.get("db") {
-        Some(&Bson::String(ref s)) => assert_eq!("create_and_get_users", s),
+        Some(&Bson::String(ref s)) => assert_eq!("test-client-db-create_and_get_users", s),
         _ => {
             panic!("Invalid `db` specified for user 'saghm': {:?}",
                    user.get("db"))

--- a/tests/client/db.rs
+++ b/tests/client/db.rs
@@ -33,15 +33,15 @@ fn create_collection() {
         }
     }
 
-    let db_1 = if v3_1 { "test1" } else { "test2" };
-    let db_2 = if v3_1 { "test2" } else { "test1" };
+    let db1 = if v3_1 { "test1" } else { "test2" };
+    let db2 = if v3_1 { "test2" } else { "test1" };
     
     match results[result_size - 2].get("name") {
-        Some(&Bson::String(ref name)) => assert_eq!(db_1, name),
+        Some(&Bson::String(ref name)) => assert_eq!(db1, name),
         _ => panic!("Expected BSON string!"),
     }
     match results[result_size - 1].get("name") {
-        Some(&Bson::String(ref name)) => assert_eq!(db_2, name),
+        Some(&Bson::String(ref name)) => assert_eq!(db2, name),
         _ => panic!("Expected BSON string!"),
     }
 }
@@ -80,16 +80,16 @@ fn list_collections() {
         };
     }
 
-    let db_1 = if v3_1 { "test" } else { "test2" };
-    let db_2 = if v3_1 { "test2" } else { "test" };
+    let db1 = if v3_1 { "test" } else { "test2" };
+    let db2 = if v3_1 { "test2" } else { "test" };
     
     match results[result_size - 2].get("name") {
-        Some(&Bson::String(ref name)) => assert_eq!(db_1, name),
+        Some(&Bson::String(ref name)) => assert_eq!(db1, name),
         _ => panic!("Expected BSON string!"),
     };
 
     match results[result_size - 1].get("name") {
-        Some(&Bson::String(ref name)) => assert_eq!(db_2, name),
+        Some(&Bson::String(ref name)) => assert_eq!(db2, name),
         _ => panic!("Expected BSON string!"),
     }
 }

--- a/tests/client/gridfs.rs
+++ b/tests/client/gridfs.rs
@@ -31,7 +31,7 @@ fn gen_rand_file(len: usize) -> Vec<u8> {
 
 #[test]
 fn put_get() {
-    let (fs, _, fschunks) = init_gridfs("grid_put");
+    let (fs, _, fschunks) = init_gridfs("test-client-gridfs-grid_put");
 
     let name = "grid_put_file";
     let src_len = (DEFAULT_CHUNK_SIZE as f32 * 2.5) as usize;
@@ -100,7 +100,7 @@ fn put_get() {
 
 #[test]
 fn remove() {
-    let (fs, fsfiles, fschunks) = init_gridfs("grid_remove");
+    let (fs, fsfiles, fschunks) = init_gridfs("test-client-gridfs-grid_remove");
 
     let name = "grid_remove_file";
     let src_len = (DEFAULT_CHUNK_SIZE as f32 * 1.5) as usize;
@@ -127,7 +127,7 @@ fn remove() {
 
 #[test]
 fn remove_id() {
-    let (fs, fsfiles, fschunks) = init_gridfs("grid_remove_id");
+    let (fs, fsfiles, fschunks) = init_gridfs("test-client-gridfs-grid_remove_id");
 
     let name = "grid_remove_id_file";
     let src_len = (DEFAULT_CHUNK_SIZE as f32 * 1.5) as usize;
@@ -152,7 +152,7 @@ fn remove_id() {
 
 #[test]
 fn find() {
-    let (fs, _, _) = init_gridfs("grid_find");
+    let (fs, _, _) = init_gridfs("test-client-gridfs-grid_find");
 
     let name = "grid_find_file";
     let name2 = "grid_find_file_2";

--- a/tests/client/mod.rs
+++ b/tests/client/mod.rs
@@ -28,10 +28,8 @@ fn database_names() {
 
     let base_results = client.database_names().expect("Failed to execute database_names.");
 
-    let db_version = client.db("whatever").version().unwrap();
-    let v3_1 = db_version.major <= 3 && db_version.minor <= 1;
-    let admin_db_name = if v3_1 { "local" } else { "admin" };
-    assert_eq!(admin_db_name, base_results[0]);
+    assert!(results.contains(&"admin".to_owned()));
+    assert!(results.contains(&"local".to_owned()));
 
     assert!(!base_results.contains(&"test-client-mod-database_names".to_owned()));
     assert!(!base_results.contains(&"test-client-mod-database_names_2".to_owned()));
@@ -48,6 +46,7 @@ fn database_names() {
 
     // Check new dbs
     let results = client.database_names().expect("Failed to execute database_names.");
+    assert!(results.contains(&"admin".to_owned()));
     assert!(results.contains(&"local".to_owned()));
     assert!(results.contains(&"test-client-mod-database_names".to_owned()));
     assert!(results.contains(&"test-client-mod-database_names_2".to_owned()));
@@ -64,10 +63,8 @@ fn is_sync() {
 
     let base_results = client.database_names().expect("Failed to execute database_names.");
 
-    let db_version = client.db("whatever").version().unwrap();
-    let v3_1 = db_version.major <= 3 && db_version.minor <= 1;
-    let admin_db_name = if v3_1 { "local" } else { "admin" };
-    assert_eq!(admin_db_name, base_results[0]);
+    assert!(results.contains(&"admin".to_owned()));
+    assert!(results.contains(&"local".to_owned()));
 
     assert!(!base_results.contains(&"test-client-mod-is_sync".to_owned()));
     assert!(!base_results.contains(&"test-client-mod-is_sync_2".to_owned()));
@@ -95,6 +92,7 @@ fn is_sync() {
 
     // Check new dbs
     let results = client.database_names().expect("Failed to execute database_names.");
+    assert!(results.contains(&"admin".to_owned()));
     assert!(results.contains(&"local".to_owned()));
     assert!(results.contains(&"test-client-mod-is_sync".to_owned()));
     assert!(results.contains(&"test-client-mod-is_sync_2".to_owned()));

--- a/tests/client/mod.rs
+++ b/tests/client/mod.rs
@@ -28,9 +28,8 @@ fn database_names() {
 
     let base_results = client.database_names().expect("Failed to execute database_names.");
 
-    assert!(results.contains(&"admin".to_owned()));
-    assert!(results.contains(&"local".to_owned()));
-
+    assert!(base_results.contains(&"admin".to_owned()));
+    assert!(base_results.contains(&"local".to_owned()));
     assert!(!base_results.contains(&"test-client-mod-database_names".to_owned()));
     assert!(!base_results.contains(&"test-client-mod-database_names_2".to_owned()));
 
@@ -63,8 +62,8 @@ fn is_sync() {
 
     let base_results = client.database_names().expect("Failed to execute database_names.");
 
-    assert!(results.contains(&"admin".to_owned()));
-    assert!(results.contains(&"local".to_owned()));
+    assert!(base_results.contains(&"admin".to_owned()));
+    assert!(base_results.contains(&"local".to_owned()));
 
     assert!(!base_results.contains(&"test-client-mod-is_sync".to_owned()));
     assert!(!base_results.contains(&"test-client-mod-is_sync_2".to_owned()));

--- a/tests/client/mod.rs
+++ b/tests/client/mod.rs
@@ -15,21 +15,17 @@ use std::thread;
 
 #[test]
 fn database_names() {
-    let client = Client::connect("localhost", 27018).unwrap();
-    let state_results = client.database_names().expect("Failed to execute database_names.");
-    for name in state_results {
-        if name != "local" {
-            client.drop_database(&name[..]).expect("Failed to drop database from server.");
-        }
-    }
+    let client = Client::connect("localhost", 27017).unwrap();
+    client.drop_database("test-client-mod-database_names").expect("Failed to drop database");
+    client.drop_database("test-client-mod-database_names_2").expect("Failed to drop database");
 
     let base_results = client.database_names().expect("Failed to execute database_names.");
-    assert_eq!(1, base_results.len());
+    let base_db_count = base_results.len();
     assert_eq!("local", base_results[0]);
 
     // Build dbs
-    let db1 = client.db("new_db");
-    let db2 = client.db("new_db_2");
+    let db1 = client.db("test-client-mod-database_names");
+    let db2 = client.db("test-client-mod-database_names_2");
     db1.collection("test1")
         .insert_one(bson::Document::new(), None)
         .expect("Failed to insert placeholder document into collection");
@@ -39,12 +35,11 @@ fn database_names() {
 
     // Check new dbs
     let results = client.database_names().expect("Failed to execute database_names.");
-    assert_eq!(3, results.len());
+    assert_eq!(base_db_count + 2, results.len());
     assert!(results.contains(&"local".to_owned()));
-    assert!(results.contains(&"new_db".to_owned()));
-    assert!(results.contains(&"new_db_2".to_owned()));
+    assert!(results.contains(&"test-client-mod-database_names".to_owned()));
+    assert!(results.contains(&"test-client-mod-database_names_2".to_owned()));
 }
-
 
 #[test]
 fn is_master() {
@@ -55,37 +50,33 @@ fn is_master() {
 
 #[test]
 fn is_sync() {
-    let client = Client::connect("localhost", 27018).unwrap();
-    let state_results = client.database_names().expect("Failed to execute database_names.");
-    for name in state_results {
-        if name != "local" {
-            client.drop_database(&name[..]).expect("Failed to drop database from server.");
-        }
-    }
-
+    let client = Client::connect("localhost", 27017).unwrap();
     let client1 = client.clone();
     let client2 = client.clone();
 
+    client.drop_database("test-client-mod-is_sync").expect("failed to drop database");
+    client.drop_database("test-client-mod-is_sync_2").expect("failed to drop database");
+
     let base_results = client.database_names().expect("Failed to execute database_names.");
-    assert_eq!(1, base_results.len());
+    let base_db_count = base_results.len();
     assert_eq!("local", base_results[0]);
 
     let child1 = thread::spawn(move || {
-        let db = client1.db("concurrent_db");
+        let db = client1.db("test-client-mod-is_sync");
         db.collection("test1")
             .insert_one(bson::Document::new(), None)
             .expect("Failed to insert placeholder document into collection");
         let results = client1.database_names().expect("Failed to execute database_names.");
-        assert!(results.contains(&"concurrent_db".to_owned()));
+        assert!(results.contains(&"test-client-mod-is_sync".to_owned()));
     });
 
     let child2 = thread::spawn(move || {
-        let db = client2.db("concurrent_db_2");
+        let db = client2.db("test-client-mod-is_sync_2");
         db.collection("test2")
             .insert_one(bson::Document::new(), None)
             .expect("Failed to insert placeholder document into collection");
         let results = client2.database_names().expect("Failed to execute database_names.");
-        assert!(results.contains(&"concurrent_db_2".to_owned()));
+        assert!(results.contains(&"test-client-mod-is_sync_2".to_owned()));
     });
 
     let _ = child1.join();
@@ -93,8 +84,8 @@ fn is_sync() {
 
     // Check new dbs
     let results = client.database_names().expect("Failed to execute database_names.");
-    assert_eq!(3, results.len());
+    assert_eq!(base_db_count + 2, results.len());
     assert!(results.contains(&"local".to_owned()));
-    assert!(results.contains(&"concurrent_db".to_owned()));
-    assert!(results.contains(&"concurrent_db_2".to_owned()));
+    assert!(results.contains(&"test-client-mod-is_sync".to_owned()));
+    assert!(results.contains(&"test-client-mod-is_sync_2".to_owned()));
 }

--- a/tests/client/mod.rs
+++ b/tests/client/mod.rs
@@ -20,8 +20,9 @@ fn database_names() {
     client.drop_database("test-client-mod-database_names_2").expect("Failed to drop database");
 
     let base_results = client.database_names().expect("Failed to execute database_names.");
-    let base_db_count = base_results.len();
     assert_eq!("local", base_results[0]);
+    assert!(!results.contains(&"test-client-mod-database_names".to_owned()));
+    assert!(!results.contains(&"test-client-mod-database_names_2".to_owned()));
 
     // Build dbs
     let db1 = client.db("test-client-mod-database_names");
@@ -35,7 +36,6 @@ fn database_names() {
 
     // Check new dbs
     let results = client.database_names().expect("Failed to execute database_names.");
-    assert_eq!(base_db_count + 2, results.len());
     assert!(results.contains(&"local".to_owned()));
     assert!(results.contains(&"test-client-mod-database_names".to_owned()));
     assert!(results.contains(&"test-client-mod-database_names_2".to_owned()));
@@ -58,8 +58,9 @@ fn is_sync() {
     client.drop_database("test-client-mod-is_sync_2").expect("failed to drop database");
 
     let base_results = client.database_names().expect("Failed to execute database_names.");
-    let base_db_count = base_results.len();
     assert_eq!("local", base_results[0]);
+    assert!(!results.contains(&"test-client-mod-is_sync".to_owned()));
+    assert!(!results.contains(&"test-client-mod-is_sync_2".to_owned()));
 
     let child1 = thread::spawn(move || {
         let db = client1.db("test-client-mod-is_sync");
@@ -84,7 +85,6 @@ fn is_sync() {
 
     // Check new dbs
     let results = client.database_names().expect("Failed to execute database_names.");
-    assert_eq!(base_db_count + 2, results.len());
     assert!(results.contains(&"local".to_owned()));
     assert!(results.contains(&"test-client-mod-is_sync".to_owned()));
     assert!(results.contains(&"test-client-mod-is_sync_2".to_owned()));

--- a/tests/client/wire_protocol.rs
+++ b/tests/client/wire_protocol.rs
@@ -5,15 +5,12 @@ use mongodb::wire_protocol::flags::{OpInsertFlags, OpQueryFlags, OpUpdateFlags};
 use mongodb::wire_protocol::operations::Message;
 use std::net::TcpStream;
 
-fn drop_db() {
-    let client = Client::connect("localhost", 27017).unwrap();
-    let db = client.db("test");
-    db.drop_database().unwrap();
-}
-
 #[test]
 fn insert_single_key_doc() {
-    drop_db();
+    let client = Client::connect("localhost", 27017).unwrap();
+    let db = client.db("test-client-wire_protocol-insert_single_key_doc");
+    db.drop_database().unwrap();
+    
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
             let doc = doc! { "foo" => 42.0 };
@@ -71,7 +68,10 @@ fn insert_single_key_doc() {
 
 #[test]
 fn insert_multi_key_doc() {
-    drop_db();
+    let client = Client::connect("localhost", 27017).unwrap();
+    let db = client.db("test-client-wire_protocol-insert_multi_key_doc");
+    db.drop_database().unwrap();
+
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
             let doc = doc! {
@@ -137,7 +137,10 @@ fn insert_multi_key_doc() {
 
 #[test]
 fn insert_docs() {
-    drop_db();
+    let client = Client::connect("localhost", 27017).unwrap();
+    let db = client.db("test-client-wire_protocol-insert_docs");
+    db.drop_database().unwrap();
+
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
             let doc1 = doc! {
@@ -214,7 +217,10 @@ fn insert_docs() {
 
 #[test]
 fn insert_update_then_query() {
-    drop_db();
+    let client = Client::connect("localhost", 27017).unwrap();
+    let db = client.db("test-client-wire_protocol-insert_update_then_query");
+    db.drop_database().unwrap();
+
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
             let doc = doc! { "foo" => 42.0 };

--- a/tests/client/wire_protocol.rs
+++ b/tests/client/wire_protocol.rs
@@ -17,7 +17,7 @@ fn insert_single_key_doc() {
 
             let docs = vec![doc];
             let flags = OpInsertFlags::no_flags();
-            let name = "test.single_key".to_owned();
+            let name = "test-client-wire_protocol-insert_single_key_doc.single_key".to_owned();
             let res = Message::new_insert(1, flags, name, docs);
 
             let cm = match res {
@@ -32,7 +32,7 @@ fn insert_single_key_doc() {
 
             let doc = Document::new();
             let flags = OpQueryFlags::no_flags();
-            let name = "test.single_key".to_owned();
+            let name = "test-client-wire_protocol-insert_single_key_doc.single_key".to_owned();
             let res = Message::new_query(1, flags, name, 0, 0, doc, None);
 
             let cm = match res {
@@ -81,7 +81,7 @@ fn insert_multi_key_doc() {
 
             let docs = vec![doc];
             let flags = OpInsertFlags::no_flags();
-            let name = "test.multi_key".to_owned();
+            let name = "test-client-wire_protocol-insert_multi_key_doc.multi_key".to_owned();
             let res = Message::new_insert(1, flags, name, docs);
 
             let cm = match res {
@@ -96,7 +96,7 @@ fn insert_multi_key_doc() {
 
             let doc = Document::new();
             let flags = OpQueryFlags::no_flags();
-            let name = "test.multi_key".to_owned();
+            let name = "test-client-wire_protocol-insert_multi_key_doc.multi_key".to_owned();
             let res = Message::new_query(1, flags, name, 0, 0, doc, None);
 
             let cm = match res {
@@ -154,7 +154,7 @@ fn insert_docs() {
 
             let docs = vec![doc1, doc2];
             let flags = OpInsertFlags::no_flags();
-            let name = "test.multi_doc".to_owned();
+            let name = "test-client-wire_protocol-insert_docs.multi_doc".to_owned();
             let res = Message::new_insert(1, flags, name, docs);
 
             let cm = match res {
@@ -169,7 +169,7 @@ fn insert_docs() {
 
             let doc = Document::new();
             let flags = OpQueryFlags::no_flags();
-            let name = "test.multi_doc".to_owned();
+            let name = "test-client-wire_protocol-insert_docs.multi_doc".to_owned();
             let res = Message::new_query(1, flags, name, 0, 0, doc, None);
 
             let cm = match res {
@@ -227,7 +227,7 @@ fn insert_update_then_query() {
 
             let docs = vec![doc];
             let flags = OpInsertFlags::no_flags();
-            let name = "test.update".to_owned();
+            let name = "test-client-wire_protocol-insert_update_then_query.update".to_owned();
             let res = Message::new_insert(1, flags, name, docs);
 
             let cm = match res {
@@ -245,7 +245,7 @@ fn insert_update_then_query() {
             let update = doc! { "foo" => "bar" };
 
             let flags = OpUpdateFlags::no_flags();
-            let name = "test.update".to_owned();
+            let name = "test-client-wire_protocol-insert_update_then_query.update".to_owned();
             let res = Message::new_update(2, name, flags, selector, update);
 
             let cm = match res {
@@ -260,7 +260,7 @@ fn insert_update_then_query() {
 
             let doc = Document::new();
             let flags = OpQueryFlags::no_flags();
-            let name = "test.update".to_owned();
+            let name = "test-client-wire_protocol-insert_update_then_query.update".to_owned();
             let res = Message::new_query(3, flags, name, 0, 0, doc, None);
 
             let cm = match res {


### PR DESCRIPTION
🌵:dancer:

## parallelization.

This makes our tests parallelizable by naming databases on a per-module level, and collections on a per-test level. When necessary (mostly in `client/mod` and `client/db`), databases will be named on a per-test level.

## a tale of two servers.

Previously in `client/mod`, we required an extra server on 27018, since we were wiping all databases at the start of each test and checking the number of databases listed. 

I didn't find this very necessary, as long as the databases we _know_ should exist, exist. This includes the base `local`/`admin` databases, along with databases we create ourselves, so it seems to cover the cases for calling `database_names`.

I modified the tests to check these databases specifically, and removed 27018 from the travis config. Less test suite setup 🚀 

## oops.
This includes the db.version() test switch because I forgot to switch to master before starting this branch, and now it's too much work to backtrack and take it out. It's a small change. nbd.