### PR TITLE
The autoIndexId option removed in version 3.4

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -301,8 +301,7 @@ impl ThreadedDatabase for Database {
         let coll_options = options.unwrap_or_else(CreateCollectionOptions::new);
         let mut doc = doc! {
             "create" => name,
-            "capped" => (coll_options.capped),
-            "auto_index_id" => (coll_options.auto_index_id)
+            "capped" => (coll_options.capped)
         };
 
         if let Some(i) = coll_options.size {

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -6,7 +6,6 @@ use db::roles::Role;
 #[derive(Default)]
 pub struct CreateCollectionOptions {
     pub capped: bool,
-    pub auto_index_id: bool,
     pub size: Option<i64>,
     pub max: Option<i64>,
     pub use_power_of_two_sizes: bool,
@@ -17,7 +16,6 @@ impl CreateCollectionOptions {
     pub fn new() -> CreateCollectionOptions {
         CreateCollectionOptions {
             capped: false,
-            auto_index_id: true,
             size: None,
             max: None,
             use_power_of_two_sizes: true,

--- a/tests/apm/mod.rs
+++ b/tests/apm/mod.rs
@@ -92,7 +92,7 @@ fn logging() {
     // Create collection started
     read_first_non_monitor_line(&mut file, &mut line);
     assert_eq!("COMMAND.create_collection 127.0.0.1:27017 STARTED: { create: \"logging\", \
-                capped: false, auto_index_id: true, flags: 1 }\n",
+                capped: false, flags: 1 }\n",
                &line);
 
     // Create collection completed


### PR DESCRIPTION
Deprecated since version 3.2 (released at Dec 8, 2015)
The autoIndexId option will be removed in version 3.4.