### PR TITLE
remove specifications of default options

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -95,3 +95,8 @@ impl WriteConcern {
         bson
     }
 }
+
+pub fn merge_options<T: Into<bson::Document>>(document: bson::Document, options: T) -> bson::Document {
+    let options_doc: bson::Document = options.into();
+    document.into_iter().chain(options_doc.into_iter()).collect()
+}

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -1,28 +1,59 @@
 //! Options for database-level commands.
-use bson::Document;
+use bson::{Bson, Document};
 use common::WriteConcern;
 use db::roles::Role;
 
 #[derive(Default)]
 pub struct CreateCollectionOptions {
-    pub capped: bool,
-    pub auto_index_id: bool,
+    pub capped: Option<bool>,
+    pub auto_index_id: Option<bool>,
     pub size: Option<i64>,
     pub max: Option<i64>,
-    pub use_power_of_two_sizes: bool,
-    pub no_padding: bool,
+    pub use_power_of_two_sizes: Option<bool>,
+    pub no_padding: Option<bool>,
 }
 
 impl CreateCollectionOptions {
     pub fn new() -> CreateCollectionOptions {
-        CreateCollectionOptions {
-            capped: false,
-            auto_index_id: true,
-            size: None,
-            max: None,
-            use_power_of_two_sizes: true,
-            no_padding: false,
+        Default::default()
+    }
+}
+
+impl From<CreateCollectionOptions> for Document {
+    fn from(options: CreateCollectionOptions) -> Self {
+        let mut document = Document::new();
+
+        if let Some(capped) = options.capped {
+            document.insert("capped", Bson::Boolean(capped));
         }
+
+        if let Some(auto_index_id) = options.auto_index_id {
+            document.insert("autoIndexId", Bson::Boolean(auto_index_id));
+        }
+
+        if let Some(size) = options.size {
+            document.insert("size", Bson::I64(size));
+        }
+
+        if let Some(max) = options.max {
+            document.insert("max", Bson::I64(max));
+        }
+
+        let mut flags = 0;
+
+        if let Some(true) = options.use_power_of_two_sizes {
+            flags += 1;
+        }
+
+        if let Some(true) = options.no_padding {
+            flags += 2;
+        }
+
+        if options.use_power_of_two_sizes.is_some() || options.no_padding.is_some() {
+            document.insert("flags", Bson::I32(flags));
+        }
+
+        document
     }
 }
 
@@ -35,25 +66,52 @@ pub struct CreateUserOptions {
 
 impl CreateUserOptions {
     pub fn new() -> CreateUserOptions {
-        CreateUserOptions {
-            custom_data: None,
-            roles: vec![],
-            write_concern: None,
+        Default::default()
+    }
+}
+
+impl From<CreateUserOptions> for Document {
+    fn from(options: CreateUserOptions) -> Self {
+        let mut document = Document::new();
+
+        if let Some(custom_data) = options.custom_data {
+            document.insert("customData", Bson::Document(custom_data));
         }
+
+        document.insert("roles", Role::to_bson_array(options.roles));
+
+        if let Some(write_concern) = options.write_concern {
+            document.insert("writeConcern", Bson::Document(write_concern.to_bson()));
+        }
+
+        document
     }
 }
 
 #[derive(Default)]
 pub struct UserInfoOptions {
-    pub show_credentials: bool,
-    pub show_privileges: bool,
+    pub show_credentials: Option<bool>,
+    pub show_privileges: Option<bool>,
 }
 
 impl UserInfoOptions {
     pub fn new() -> UserInfoOptions {
-        UserInfoOptions {
-            show_credentials: false,
-            show_privileges: false,
+        Default::default()
+    }
+}
+
+impl From<UserInfoOptions> for Document {
+    fn from(options: UserInfoOptions) -> Self {
+        let mut document = Document::new();
+
+        if let Some(show_credentials) = options.show_credentials {
+            document.insert("showCredentials", Bson::Boolean(show_credentials));
         }
+
+        if let Some(show_privileges) = options.show_privileges {
+            document.insert("showPrivileges", Bson::Boolean(show_privileges));
+        }
+
+        document
     }
 }

--- a/src/topology/monitor.rs
+++ b/src/topology/monitor.rs
@@ -250,7 +250,11 @@ impl Monitor {
 
     /// Returns an isMaster server response using an owned monitor socket.
     pub fn is_master(&self) -> Result<(Cursor, i64)> {
-        let options = FindOptions::new().with_limit(1);
+        let mut options = FindOptions::new();
+        options.limit = Some(1);
+        options.batch_size = Some(1);
+
+
         let flags = OpQueryFlags::with_find_options(&options);
         let mut filter = bson::Document::new();
         filter.insert("isMaster", Bson::I32(1));
@@ -262,12 +266,9 @@ impl Monitor {
         let cursor = try!(Cursor::query_with_stream(stream,
                                                     self.client.clone(),
                                                     String::from("local.$cmd"),
-                                                    1,
                                                     flags,
-                                                    options.skip as i32,
-                                                    1,
                                                     filter.clone(),
-                                                    options.projection.clone(),
+                                                    options,
                                                     CommandType::IsMaster,
                                                     false,
                                                     None));

--- a/src/wire_protocol/flags.rs
+++ b/src/wire_protocol/flags.rs
@@ -55,7 +55,7 @@ impl OpQueryFlags {
             flags.insert(TAILABLE_CURSOR);
         }
 
-        if options.op_log_replay {
+        if options.oplog_replay {
             flags.insert(OPLOG_RELAY);
         }
 

--- a/tests/apm/mod.rs
+++ b/tests/apm/mod.rs
@@ -57,7 +57,8 @@ fn logging() {
     let _ = fs::remove_file("test_apm_log.txt");
 
     // Reset State
-    let reset_client = Client::connect("localhost", 27017).expect("Failed to connect to localhost:27017");
+    let reset_client = Client::connect("localhost", 27017)
+        .expect("Failed to connect to localhost:27017");
     let reset_db = reset_client.db("test-apm-mod");
     let reset_coll = reset_db.collection("logging");
     reset_coll.drop().unwrap();
@@ -70,7 +71,7 @@ fn logging() {
     let coll = db.collection("logging");
     db.create_collection("logging", None).unwrap();
     coll.drop().unwrap();
-    
+
     let doc1 = doc! { "_id" => 1 };
     let doc2 = doc! { "_id" => 2 };
     let doc3 = doc! { "_id" => 3 };
@@ -91,8 +92,7 @@ fn logging() {
 
     // Create collection started
     read_first_non_monitor_line(&mut file, &mut line);
-    assert_eq!("COMMAND.create_collection 127.0.0.1:27017 STARTED: { create: \"logging\", \
-                capped: false, auto_index_id: true, flags: 1 }\n",
+    assert_eq!("COMMAND.create_collection 127.0.0.1:27017 STARTED: { create: \"logging\" }\n",
                &line);
 
     // Create collection completed
@@ -118,7 +118,7 @@ fn logging() {
     line.clear();
     read_first_non_monitor_line(&mut file, &mut line);
     assert_eq!("COMMAND.insert_one 127.0.0.1:27017 STARTED: { insert: \"logging\", documents: [{ \
-                _id: 1 }], ordered: true, writeConcern: { w: 1, wtimeout: 0, j: false } }\n",
+                _id: 1 }] }\n",
                &line);
 
     // First insert completed
@@ -131,7 +131,7 @@ fn logging() {
     line.clear();
     read_first_non_monitor_line(&mut file, &mut line);
     assert_eq!("COMMAND.insert_one 127.0.0.1:27017 STARTED: { insert: \"logging\", documents: [{ \
-                _id: 2 }], ordered: true, writeConcern: { w: 1, wtimeout: 0, j: false } }\n",
+                _id: 2 }] }\n",
                &line);
 
     // Second insert completed
@@ -144,7 +144,7 @@ fn logging() {
     line.clear();
     read_first_non_monitor_line(&mut file, &mut line);
     assert_eq!("COMMAND.insert_one 127.0.0.1:27017 STARTED: { insert: \"logging\", documents: [{ \
-                _id: 3 }], ordered: true, writeConcern: { w: 1, wtimeout: 0, j: false } }\n",
+                _id: 3 }] }\n",
                &line);
 
     // Third insert completed
@@ -156,16 +156,16 @@ fn logging() {
     // Find command started
     line.clear();
     read_first_non_monitor_line(&mut file, &mut line);
-    assert_eq!("COMMAND.find 127.0.0.1:27017 STARTED: { find: \"logging\", filter: {  }, \
-                projection: {  }, skip: 0, limit: 0, batchSize: 20, sort: {  } }\n",
+    assert_eq!("COMMAND.find 127.0.0.1:27017 STARTED: { find: \"logging\", filter: { _id: { \
+                $gt: 1 } } }\n",
                &line);
 
     // Find command completed
     line.clear();
     read_first_non_monitor_line(&mut file, &mut line);
     assert!(line.starts_with("COMMAND.find 127.0.0.1:27017 COMPLETED: { cursor: { id: 0, ns: \
-                              \"test-apm-mod.logging\", firstBatch: [{ _id: 2 }, { _id: 3 }] }, ok: 1 } \
-                              ("));
+                              \"test-apm-mod.logging\", firstBatch: [{ _id: 2 }, { _id: 3 }] }, \
+                              ok: 1 } ("));
     assert!(line.ends_with(" ns)\n"));
 
     coll.drop().unwrap();

--- a/tests/client/bulk.rs
+++ b/tests/client/bulk.rs
@@ -106,12 +106,12 @@ fn bulk_ordered_mix() {
         WriteModel::ReplaceOne {
             filter: doc! { "_id" => (3) },
             replacement: doc! { "x" => (37) },
-            upsert: true,
+            upsert: Some(true),
         },
         WriteModel::UpdateMany {
             filter: doc! { "_id" => { "$lt" => (3) } },
             update: doc! { "$inc" => { "x" => (1) } },
-            upsert: false,
+            upsert: Some(false),
         },
         WriteModel::DeleteOne { filter: doc! {
             "_id" => (4)
@@ -123,7 +123,7 @@ fn bulk_ordered_mix() {
         WriteModel::UpdateOne {
             filter: doc! { "_id" => (6) },
             update: doc! { "$set" =>  { "x" => (62) } },
-            upsert: true
+            upsert: Some(true)
         },
         WriteModel::InsertOne { document: doc! {
             "_id" => (101),

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -186,7 +186,7 @@ fn find_one_and_replace() {
 
     // Replace with 'new' option
     let mut opts = FindOneAndUpdateOptions::new();
-    opts.return_document = ReturnDocument::After;
+    opts.return_document = Some(ReturnDocument::After);
     let result = coll.find_one_and_replace(doc3.clone(), doc2.clone(), Some(opts))
         .expect("Failed to execute find_one_and_replace command.");
 
@@ -267,11 +267,9 @@ fn aggregate() {
 
     // Grab ids from aggregated docs
     let vec: Vec<_> = results.iter()
-        .filter_map(|bdoc| {
-            match bdoc.get("_id") {
-                Some(&Bson::String(ref tag)) => Some(tag.to_owned()),
-                _ => None,
-            }
+        .filter_map(|bdoc| match bdoc.get("_id") {
+            Some(&Bson::String(ref tag)) => Some(tag.to_owned()),
+            _ => None,
         })
         .collect();
 

--- a/tests/client/cursor.rs
+++ b/tests/client/cursor.rs
@@ -2,6 +2,7 @@ use bson::{Bson, Document};
 
 use mongodb::{Client, CommandType, ThreadedClient};
 use mongodb::common::{ReadMode, ReadPreference};
+use mongodb::coll::options::FindOptions;
 use mongodb::db::ThreadedDatabase;
 use mongodb::cursor::Cursor;
 use mongodb::wire_protocol::flags::OpQueryFlags;
@@ -25,14 +26,14 @@ fn cursor_features() {
     let doc = Document::new();
     let flags = OpQueryFlags::empty();
 
+    let mut options = FindOptions::new();
+    options.batch_size = Some(3);
+
     let result = Cursor::query(client.clone(),
                                "test-client-cursor.cursor_test".to_owned(),
-                               3,
                                flags,
-                               0,
-                               0,
                                doc,
-                               None,
+                               options,
                                CommandType::Find,
                                false,
                                ReadPreference::new(ReadMode::Primary, None));

--- a/tests/json/crud/options.rs
+++ b/tests/json/crud/options.rs
@@ -26,16 +26,16 @@ impl FromJson for CountOptions {
         let mut options = CountOptions::new();
 
         options.skip = match object.get("skip") {
-            Some(&Json::I64(n)) => n as u64,
-            Some(&Json::U64(n)) => n as u64,
-            Some(&Json::F64(n)) => n as u64,
+            Some(&Json::I64(n)) => Some(n),
+            Some(&Json::U64(n)) => Some(n as i64),
+            Some(&Json::F64(n)) => Some(n as i64),
             _ => options.skip,
         };
 
         options.limit = match object.get("limit") {
-            Some(&Json::I64(n)) => n as i64,
-            Some(&Json::U64(n)) => n as i64,
-            Some(&Json::F64(n)) => n as i64,
+            Some(&Json::I64(n)) => Some(n),
+            Some(&Json::U64(n)) => Some(n as i64),
+            Some(&Json::F64(n)) => Some(n as i64),
             _ => options.limit,
         };
 
@@ -54,23 +54,23 @@ impl FromJson for FindOptions {
         };
 
         options.skip = match object.get("skip") {
-            Some(&Json::I64(n)) => n as u32,
-            Some(&Json::U64(n)) => n as u32,
-            Some(&Json::F64(n)) => n as u32,
+            Some(&Json::I64(n)) => Some(n),
+            Some(&Json::U64(n)) => Some(n as i64),
+            Some(&Json::F64(n)) => Some(n as i64),
             _ => options.skip,
         };
 
         options.limit = match object.get("limit") {
-            Some(&Json::I64(n)) => n as i32,
-            Some(&Json::U64(n)) => n as i32,
-            Some(&Json::F64(n)) => n as i32,
+            Some(&Json::I64(n)) => Some(n),
+            Some(&Json::U64(n)) => Some(n as i64),
+            Some(&Json::F64(n)) => Some(n as i64),
             _ => options.limit,
         };
 
         options.batch_size = match object.get("batchSize") {
-            Some(&Json::I64(n)) => n as i32,
-            Some(&Json::U64(n)) => n as i32,
-            Some(&Json::F64(n)) => n as i32,
+            Some(&Json::I64(n)) => Some(n as i32),
+            Some(&Json::U64(n)) => Some(n as i32),
+            Some(&Json::F64(n)) => Some(n as i32),
             _ => options.batch_size,
         };
         options
@@ -82,17 +82,13 @@ impl FromJson for FindOneAndDeleteOptions {
     fn from_json(object: &Object) -> FindOneAndDeleteOptions {
         let mut options = FindOneAndDeleteOptions::new();
 
-        let f = |x| Some(Bson::from_json(x));
-        options.projection = match object.get("projection").and_then(f) {
-            Some(Bson::Document(doc)) => Some(doc),
-            _ => None,
-        };
+        if let Some(Bson::Document(projection)) = object.get("projection").map(Bson::from_json) {
+            options.projection = Some(projection);
+        }
 
-        let f = |x| Some(Bson::from_json(x));
-        options.sort = match object.get("sort").and_then(f) {
-            Some(Bson::Document(doc)) => Some(doc),
-            _ => None,
-        };
+        if let Some(Bson::Document(sort)) = object.get("sort").map(Bson::from_json) {
+            options.sort = Some(sort);
+        }
 
         options
     }
@@ -102,32 +98,26 @@ impl FromJson for FindOneAndUpdateOptions {
     fn from_json(object: &Object) -> FindOneAndUpdateOptions {
         let mut options = FindOneAndUpdateOptions::new();
 
-        let f = |x| Some(Bson::from_json(x));
-        options.projection = match object.get("projection").and_then(f) {
-            Some(Bson::Document(doc)) => Some(doc),
-            _ => None,
-        };
+        if let Some(Bson::Document(projection)) = object.get("projection").map(Bson::from_json) {
+            options.projection = Some(projection);
+        }
 
-        let f = |x| Some(Bson::from_json(x));
-        options.return_document = match object.get("returnDocument").and_then(f) {
-            Some(Bson::String(ref s)) => {
-                match s.as_ref() {
-                    "After" => ReturnDocument::After,
-                    _ => ReturnDocument::Before,
-                }
-            }
-            _ => ReturnDocument::Before,
-        };
+        if let Some(Bson::String(s)) = object.get("returnDocument").map(Bson::from_json) {
+            match s.as_ref() {
+                "After" => options.return_document = Some(ReturnDocument::After),
+                "Before" => options.return_document = Some(ReturnDocument::Before),
+                _ => {}
+            };
+        }
 
-        let f = |x| Some(Bson::from_json(x));
-        options.sort = match object.get("sort").and_then(f) {
-            Some(Bson::Document(doc)) => Some(doc),
-            _ => None,
-        };
 
-        let f = |x| Some(Bson::from_json(x));
-        options.upsert = var_match!(object.get("upsert").and_then(f),
-                                        Some(Bson::Boolean(b)) => b);
+        if let Some(Bson::Document(sort)) = object.get("sort").map(Bson::from_json) {
+            options.sort = Some(sort);
+        }
+
+        if let Some(Bson::Boolean(upsert)) = object.get("upsert").map(Bson::from_json) {
+            options.upsert = Some(upsert);
+        }
 
         options
     }


### PR DESCRIPTION
Replaces #183 and moves us a bit closer towards #179 

This is a big one; some of the changes of the options structs were relatively easy to integrate, but others (I'm looking you, `FindOptions`) required quite a bit of finagling with parts of the code I hadn't looked closely at in a while.

All tests pass on 3.2, and the only two failing tests on 3.4 are `apm::logging` (I'll need to look into this more closely) and `client::db::create_and_get_users` (which seems to return the users in a different order than before), both of which appear to be issues with the tests not being compatible with 3.4 rather than the driver itself. This means the driver should work with 3.4 after this is merged!