### PR TITLE
fix tests for mongodb 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,23 @@ before_install:
     - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1204-3.0.14.tgz
     - tar xvf mongodb-linux-x86_64-ubuntu1204-3.0.14.tgz
     - mv mongodb-linux-x86_64-ubuntu1204-3.0.14 3.0.14
-    - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1204-3.2.11.tgz
-    - tar xvf mongodb-linux-x86_64-ubuntu1204-3.2.11.tgz
-    - mv mongodb-linux-x86_64-ubuntu1204-3.2.11 3.2.11
+    - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1204-3.2.12.tgz
+    - tar xvf mongodb-linux-x86_64-ubuntu1204-3.2.12.tgz
+    - mv mongodb-linux-x86_64-ubuntu1204-3.2.12 3.2.12
+    - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1204-3.4.2.tgz
+    - tar xvf mongodb-linux-x86_64-ubuntu1204-3.4.2.tgz
+    - mv mongodb-linux-x86_64-ubuntu1204-3.4.2 3.4.2
 
 script:
-    - mkdir -p ./data/db30 ./data/db30-ssl ./data/db32 ./data/db32-ssl
+    - mkdir -p ./data/db30 ./data/db30-ssl ./data/db32 ./data/db32-ssl ./data/db34 ./data/db34-ssl
     - 3.0.14/bin/mongod --fork --dbpath ./data/db30 --syslog --port 27017
     - cargo build --verbose
     - cargo test --verbose
     - killall mongod
-    - 3.2.11/bin/mongod --fork --dbpath ./data/db32 --syslog --port 27017
+    - 3.2.12/bin/mongod --fork --dbpath ./data/db32 --syslog --port 27017
+    - cargo test --verbose
+    - killall mongod
+    - 3.4.2/bin/mongod --fork --dbpath ./data/db34 --syslog --port 27017
     - cargo test --verbose
     - killall mongod
     - 3.0.14/bin/mongod --fork --dbpath ./data/db30 --syslog --port 27017
@@ -24,8 +30,10 @@ script:
     - cargo build --features ssl --verbose
     - cargo test --features ssl --verbose
     - killall mongod
-    - 3.2.11/bin/mongod --fork --dbpath ./data/db32 --syslog --port 27017
-    - 3.2.11/bin/mongod --fork --dbpath ./data/db32-ssl --syslog --port 27018 --sslMode requireSSL --sslPEMKeyFile tests/ssl/server.pem --sslCAFile tests/ssl/ca.pem
+    - 3.2.12/bin/mongod --fork --dbpath ./data/db32 --syslog --port 27017
+    - 3.2.12/bin/mongod --fork --dbpath ./data/db32-ssl --syslog --port 27018 --sslMode requireSSL --sslPEMKeyFile tests/ssl/server.pem --sslCAFile tests/ssl/ca.pem
     - cargo test --features ssl --verbose
-
-
+    - killall mongod
+    - 3.4.2/bin/mongod --fork --dbpath ./data/db34 --syslog --port 27017
+    - 3.4.2/bin/mongod --fork --dbpath ./data/db34-ssl --syslog --port 27018 --sslMode requireSSL --sslPEMKeyFile tests/ssl/server.pem --sslCAFile tests/ssl/ca.pem
+    - cargo test --features ssl --verbose

--- a/tests/client/db.rs
+++ b/tests/client/db.rs
@@ -35,7 +35,7 @@ fn create_collection() {
 
     let db1 = if v3_1 { "test1" } else { "test2" };
     let db2 = if v3_1 { "test2" } else { "test1" };
-    
+
     match results[result_size - 2].get("name") {
         Some(&Bson::String(ref name)) => assert_eq!(db1, name),
         _ => panic!("Expected BSON string!"),
@@ -82,7 +82,7 @@ fn list_collections() {
 
     let db1 = if v3_1 { "test" } else { "test2" };
     let db2 = if v3_1 { "test2" } else { "test" };
-    
+
     match results[result_size - 2].get("name") {
         Some(&Bson::String(ref name)) => assert_eq!(db1, name),
         _ => panic!("Expected BSON string!"),
@@ -101,6 +101,17 @@ fn create_and_get_users() {
     db.drop_database().unwrap();
     db.drop_all_users(None).unwrap();
 
+    let kevin_options = CreateUserOptions {
+        custom_data: None,
+        roles: vec![Role::All(AllDatabaseRole::Read)],
+        write_concern: None,
+    };
+
+    db.create_user("kevin",
+                     "ihavenosenseofhumorandthereforeihatepuns!",
+                     Some(kevin_options))
+        .unwrap();
+
     let saghm_options = CreateUserOptions {
         custom_data: Some(doc! { "foo" => "bar" }),
         roles: vec![Role::Single {
@@ -113,16 +124,6 @@ fn create_and_get_users() {
 
     db.create_user("saghm", "ilikepuns!", Some(saghm_options)).unwrap();
 
-    let kevin_options = CreateUserOptions {
-        custom_data: None,
-        roles: vec![Role::All(AllDatabaseRole::Read)],
-        write_concern: None,
-    };
-
-    db.create_user("kevin",
-                     "ihavenosenseofhumorandthereforeihatepuns!",
-                     Some(kevin_options))
-        .unwrap();
     db.create_user("val", "ilikeangularjs!", None).unwrap();
 
     let user = db.get_user("saghm", None).unwrap();
@@ -163,13 +164,13 @@ fn create_and_get_users() {
     assert_eq!(users.len(), 3);
 
     match users[0].get("user") {
-        Some(&Bson::String(ref s)) => assert_eq!("saghm", s),
-        _ => panic!("User isn't named 'saghm' but should be"),
+        Some(&Bson::String(ref s)) => assert_eq!("kevin", s),
+        _ => panic!("User isn't named 'kevin' but should be"),
     };
 
     match users[1].get("user") {
-        Some(&Bson::String(ref s)) => assert_eq!("kevin", s),
-        _ => panic!("User isn't named 'kevin' but should be"),
+        Some(&Bson::String(ref s)) => assert_eq!("saghm", s),
+        _ => panic!("User isn't named 'saghm' but should be"),
     };
 
     match users[2].get("user") {


### PR DESCRIPTION
Two tests were failing when run against 3.4, both due to the order of things being returned having changed. Along with fixing them, I added 3.4 testing to the travis config.