### PR TITLE
refactor ClientOptions into Client builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ Here's a basic example of driver usage:
 
 ```rust
 use bson::Bson;
-use mongodb::{Client, ThreadedClient};
+use mongodb::{Connector, ThreadedClient};
 use mongodb::db::ThreadedDatabase;
 
 fn main() {
-    let client = Client::connect("localhost", 27017)
+    let connnector = Connector::new();
+    let client = connector.connect("localhost", 27017)
         .expect("Failed to initialize standalone client.");
 
     let coll = client.db("test").collection("movies");
@@ -83,7 +84,7 @@ fn main() {
 }
 ```
 
-To connect with SSL, use `Connector::with_ssl` and `Client::connect_with_options`. Afterwards, the client can be used as above (note that the server will have to be configured to accept SSL connections and that you'll have to generate your own keys and certificates):
+To connect with SSL, use `Connector::ssl`. Afterwards, the client can be used as above (note that the server will have to be configured to accept SSL connections and that you'll have to generate your own keys and certificates):
 
 ```rust
 use bson::Bson;
@@ -100,9 +101,9 @@ fn main() {
     // Whether or not to verify that the server certificate is valid. Unless you're just testing out something locally, this should ALWAYS be true.
     let verify_peer = true;
 
-    let options = Connector::with_ssl(ca_file, certificate, key_file, verify_peer);
+    let options = Connector::ssl(ca_file, certificate, key_file, verify_peer);
 
-    let client = Client::connect_with_options("localhost", 27017, options)
+    let client = connector.connect("localhost", 27017)
         .expect("Failed to initialize standalone client.");
 
     // Insert document into 'test.movies' collection

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ fn main() {
 }
 ```
 
-To connect with SSL, use `ClientOptions::with_ssl` and `Client::connect_with_options`. Afterwards, the client can be used as above (note that the server will have to be configured to accept SSL connections and that you'll have to generate your own keys and certificates):
+To connect with SSL, use `Connector::with_ssl` and `Client::connect_with_options`. Afterwards, the client can be used as above (note that the server will have to be configured to accept SSL connections and that you'll have to generate your own keys and certificates):
 
 ```rust
 use bson::Bson;
-use mongodb::{Client, ClientOptions, ThreadedClient};
+use mongodb::{Client, Connector, ThreadedClient};
 use mongodb::db::ThreadedDatabase;
 
 fn main() {
@@ -100,7 +100,7 @@ fn main() {
     // Whether or not to verify that the server certificate is valid. Unless you're just testing out something locally, this should ALWAYS be true.
     let verify_peer = true;
 
-    let options = ClientOptions::with_ssl(ca_file, certificate, key_file, verify_peer);
+    let options = Connector::with_ssl(ca_file, certificate, key_file, verify_peer);
 
     let client = Client::connect_with_options("localhost", 27017, options)
         .expect("Failed to initialize standalone client.");

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ fn main() {
 }
 ```
 
-To connect with SSL, use `Connector::ssl`. Afterwards, the client can be used as above (note that the server will have to be configured to accept SSL connections and that you'll have to generate your own keys and certificates):
+To connect with SSL, use `Connector::connect_with_ssl`. Afterwards, the client can be used as above (note that the server will have to be configured to accept SSL connections and that you'll have to generate your own keys and certificates):
 
 ```rust
 use bson::Bson;
@@ -101,9 +101,13 @@ fn main() {
     // Whether or not to verify that the server certificate is valid. Unless you're just testing out something locally, this should ALWAYS be true.
     let verify_peer = true;
 
-    let options = Connector::ssl(ca_file, certificate, key_file, verify_peer);
+    let options = Connector::ssl();
 
-    let client = connector.connect("localhost", 27017)
+    let client = connector.connect_with_ssl("mongodb://localhost:27017", 
+                                            ca_file,
+                                            certificate,
+                                            key_file,
+                                            verify_peer)
         .expect("Failed to initialize standalone client.");
 
     // Insert document into 'test.movies' collection

--- a/src/apm/event.rs
+++ b/src/apm/event.rs
@@ -43,22 +43,26 @@ pub enum CommandResult<'a> {
 impl<'a> Display for CommandResult<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match *self {
-            CommandResult::Success { duration,
-                                     ref reply,
-                                     ref command_name,
-                                     ref connection_string,
-                                     .. } => {
+            CommandResult::Success {
+                duration,
+                ref reply,
+                ref command_name,
+                ref connection_string,
+                ..
+            } => {
                 fmt.write_fmt(format_args!("COMMAND.{} {} COMPLETED: {} ({} ns)",
                                            command_name,
                                            connection_string,
                                            reply,
                                            duration.separated_string()))
             }
-            CommandResult::Failure { duration,
-                                     ref command_name,
-                                     failure,
-                                     ref connection_string,
-                                     .. } => {
+            CommandResult::Failure {
+                duration,
+                ref command_name,
+                failure,
+                ref connection_string,
+                ..
+            } => {
                 fmt.write_fmt(format_args!("COMMAND.{} {} FAILURE: {} ({} ns)",
                                            command_name,
                                            connection_string,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -86,11 +86,11 @@ impl Authenticator {
         };
 
         Ok(InitialData {
-            message: message,
-            response: response,
-            nonce: nonce,
-            conversation_id: id,
-        })
+               message: message,
+               response: response,
+               nonce: nonce,
+               conversation_id: id,
+           })
     }
 
     fn next(&self, password: String, initial_data: InitialData) -> Result<AuthData> {
@@ -101,8 +101,9 @@ impl Authenticator {
                                                       String,
                                                       u32);
 
-        let rnonce_b64 = rnonce_opt
-            .ok_or_else(|| ResponseError(String::from("Invalid rnonce returned")))?;
+        let rnonce_b64 =
+            rnonce_opt
+                .ok_or_else(|| ResponseError(String::from("Invalid rnonce returned")))?;
 
         // Validate rnonce to make sure server isn't malicious
         if !rnonce_b64.starts_with(&initial_data.nonce[..]) {
@@ -112,11 +113,13 @@ impl Authenticator {
         let salt_b64 = salt_opt
             .ok_or_else(|| ResponseError(String::from("Invalid salt returned")))?;
 
-        let salt = base64::decode(salt_b64.as_bytes())
-            .or_else(|e| Err(ResponseError(format!("Invalid base64 salt returned: {}", e))))?;
+        let salt =
+            base64::decode(salt_b64.as_bytes())
+                .or_else(|e| Err(ResponseError(format!("Invalid base64 salt returned: {}", e))))?;
 
-        let i = i_opt
-            .ok_or_else(|| ResponseError(String::from("Invalid iteration count returned")))?;
+        let i =
+            i_opt
+                .ok_or_else(|| ResponseError(String::from("Invalid iteration count returned")))?;
 
         // Hash password
         let mut md5 = Md5::new();
@@ -178,10 +181,10 @@ impl Authenticator {
         let response = try!(self.db.command(next_doc, Suppressed, None));
 
         Ok(AuthData {
-            salted_password: salted_password,
-            message: auth_message,
-            response: response,
-        })
+               salted_password: salted_password,
+               message: auth_message,
+               response: response,
+           })
     }
 
     fn finish(&self, conversation_id: Bson, auth_data: AuthData) -> Result<()> {

--- a/src/coll/batch.rs
+++ b/src/coll/batch.rs
@@ -84,8 +84,16 @@ impl From<WriteModel> for Batch {
                                        multi: true,
                                    }])
             }
-            WriteModel::ReplaceOne { filter, replacement: update, upsert } |
-            WriteModel::UpdateOne { filter, update, upsert } => {
+            WriteModel::ReplaceOne {
+                filter,
+                replacement: update,
+                upsert,
+            } |
+            WriteModel::UpdateOne {
+                filter,
+                update,
+                upsert,
+            } => {
                 Batch::Update(vec![UpdateModel {
                                        filter: filter,
                                        update: update,
@@ -93,7 +101,11 @@ impl From<WriteModel> for Batch {
                                        multi: false,
                                    }])
             }
-            WriteModel::UpdateMany { filter, update, upsert } => {
+            WriteModel::UpdateMany {
+                filter,
+                update,
+                upsert,
+            } => {
                 Batch::Update(vec![UpdateModel {
                                        filter: filter,
                                        update: update,
@@ -138,37 +150,49 @@ impl Batch {
                 match model {
                     WriteModel::DeleteOne { filter } => {
                         models.push(DeleteModel {
-                            filter: filter,
-                            multi: false,
-                        })
+                                        filter: filter,
+                                        multi: false,
+                                    })
                     }
                     WriteModel::DeleteMany { filter } => {
                         models.push(DeleteModel {
-                            filter: filter,
-                            multi: true,
-                        })
+                                        filter: filter,
+                                        multi: true,
+                                    })
                     }
                     _ => return Some(model),
                 }
             }
             Batch::Update(ref mut models) => {
                 match model {
-                    WriteModel::ReplaceOne { filter, replacement: update, upsert } |
-                    WriteModel::UpdateOne { filter, update, upsert } => {
+                    WriteModel::ReplaceOne {
+                        filter,
+                        replacement: update,
+                        upsert,
+                    } |
+                    WriteModel::UpdateOne {
+                        filter,
+                        update,
+                        upsert,
+                    } => {
                         models.push(UpdateModel {
-                            filter: filter,
-                            update: update,
-                            upsert: upsert,
-                            multi: false,
-                        })
+                                        filter: filter,
+                                        update: update,
+                                        upsert: upsert,
+                                        multi: false,
+                                    })
                     }
-                    WriteModel::UpdateMany { filter, update, upsert } => {
+                    WriteModel::UpdateMany {
+                        filter,
+                        update,
+                        upsert,
+                    } => {
                         models.push(UpdateModel {
-                            filter: filter,
-                            update: update,
-                            upsert: upsert,
-                            multi: true,
-                        })
+                                        filter: filter,
+                                        update: update,
+                                        upsert: upsert,
+                                        multi: true,
+                                    })
                     }
                     _ => return Some(model),
                 }

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -347,9 +347,9 @@ impl IndexModel {
     /// as automatically generated using the keys.
     pub fn name(&self) -> Result<String> {
         Ok(match self.options.name {
-            Some(ref name) => name.to_owned(),
-            None => try!(self.generate_index_name()),
-        })
+               Some(ref name) => name.to_owned(),
+               None => try!(self.generate_index_name()),
+           })
     }
 
     /// Generates the index name from keys.

--- a/src/common.rs
+++ b/src/common.rs
@@ -21,13 +21,13 @@ impl FromStr for ReadMode {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self> {
         Ok(match s {
-            "Primary" => ReadMode::Primary,
-            "PrimaryPreferred" => ReadMode::PrimaryPreferred,
-            "Secondary" => ReadMode::Secondary,
-            "SecondaryPreferred" => ReadMode::SecondaryPreferred,
-            "Nearest" => ReadMode::Nearest,
-            _ => return Err(ArgumentError(format!("Could not convert '{}' to ReadMode.", s))),
-        })
+               "Primary" => ReadMode::Primary,
+               "PrimaryPreferred" => ReadMode::PrimaryPreferred,
+               "Secondary" => ReadMode::Secondary,
+               "SecondaryPreferred" => ReadMode::SecondaryPreferred,
+               "Nearest" => ReadMode::Nearest,
+               _ => return Err(ArgumentError(format!("Could not convert '{}' to ReadMode.", s))),
+           })
     }
 }
 
@@ -52,12 +52,12 @@ impl ReadPreference {
         let bson_tag_sets: Vec<_> = self.tag_sets
             .iter()
             .map(|map| {
-                let mut bson_map = bson::Document::new();
-                for (key, val) in map.iter() {
-                    bson_map.insert(&key[..], Bson::String(val.to_owned()));
-                }
-                Bson::Document(bson_map)
-            })
+                     let mut bson_map = bson::Document::new();
+                     for (key, val) in map.iter() {
+                         bson_map.insert(&key[..], Bson::String(val.to_owned()));
+                     }
+                     Bson::Document(bson_map)
+                 })
             .collect();
 
         doc.insert("tag_sets", Bson::Array(bson_tag_sets));
@@ -96,7 +96,12 @@ impl WriteConcern {
     }
 }
 
-pub fn merge_options<T: Into<bson::Document>>(document: bson::Document, options: T) -> bson::Document {
+pub fn merge_options<T: Into<bson::Document>>(document: bson::Document,
+                                              options: T)
+                                              -> bson::Document {
     let options_doc: bson::Document = options.into();
-    document.into_iter().chain(options_doc.into_iter()).collect()
+    document
+        .into_iter()
+        .chain(options_doc.into_iter())
+        .collect()
 }

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -78,9 +78,7 @@ impl From<CreateUserOptions> for Document {
             document.insert("customData", Bson::Document(custom_data));
         }
 
-        let roles_barr = options.roles.into_iter()
-            .map(|r| r.to_bson())
-            .collect();
+        let roles_barr = options.roles.into_iter().map(|r| r.to_bson()).collect();
 
         document.insert("roles", Bson::Array(roles_barr));
 

--- a/src/db/roles.rs
+++ b/src/db/roles.rs
@@ -73,7 +73,7 @@ impl From<Role> for Bson {
         match role {
             Role::All(role) => Bson::String(role.to_string()),
             Role::Single { role, db } => {
-              Bson::Document(doc! {
+                Bson::Document(doc! {
                   "role" => (Bson::String(role.to_string())),
                   "db" => (Bson::String(db))
               })
@@ -85,10 +85,5 @@ impl From<Role> for Bson {
 impl Role {
     pub fn to_bson(&self) -> Bson {
         self.clone().into()
-    }
-
-    #[deprecated(since="0.2.4", note="this method will be removed in the next major release")]
-    pub fn to_bson_array(vec: Vec<Role>) -> Bson {
-        Bson::Array(vec.into_iter().map(|r| r.to_bson()).collect())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -513,7 +513,9 @@ impl ErrorCode {
             ErrorCode::CannotSatisfyWriteConcern => "CannotSatisfyWriteConcern",
             ErrorCode::OutdatedClient => "OutdatedClient",
             ErrorCode::IncompatibleAuditMetadata => "IncompatibleAuditMetadata",
-            ErrorCode::NewReplicaSetConfigurationIncompatible => "NewReplicaSetConfigurationIncompatible",
+            ErrorCode::NewReplicaSetConfigurationIncompatible => {
+                "NewReplicaSetConfigurationIncompatible"
+            }
             ErrorCode::NodeNotElectable => "NodeNotElectable",
             ErrorCode::IncompatibleShardingMetadata => "IncompatibleShardingMetadata",
             ErrorCode::DistributedClockSkewed => "DistributedClockSkewed",
@@ -544,7 +546,9 @@ impl ErrorCode {
             ErrorCode::RLPInitializationFailed => "RLPInitializationFailed",
             ErrorCode::ConfigServersInconsistent => "ConfigServersInconsistent",
             ErrorCode::FailedToSatisfyReadPreference => "FailedToSatisfyReadPreference",
-            ErrorCode::XXX_TEMP_NAME_ReadCommittedCurrentlyUnavailable => "XXX_TEMP_NAME_ReadCommittedCurrentlyUnavailable",
+            ErrorCode::XXX_TEMP_NAME_ReadCommittedCurrentlyUnavailable => {
+                "XXX_TEMP_NAME_ReadCommittedCurrentlyUnavailable"
+            }
             ErrorCode::StaleTerm => "StaleTerm",
             ErrorCode::CappedPositionLost => "CappedPositionLost",
             ErrorCode::IncompatibleShardingConfigVersion => "IncompatibleShardingConfigVersion",
@@ -554,8 +558,12 @@ impl ErrorCode {
             ErrorCode::DuplicateKey => "DuplicateKey",
             ErrorCode::InterruptedAtShutdown => "InterruptedAtShutdown",
             ErrorCode::Interrupted => "Interrupted",
-            ErrorCode::BackgroundOperationInProgressForDatabase => "BackgroundOperationInProgressForDatabase",
-            ErrorCode::BackgroundOperationInProgressForNamespace => "BackgroundOperationInProgressForNamespace",
+            ErrorCode::BackgroundOperationInProgressForDatabase => {
+                "BackgroundOperationInProgressForDatabase"
+            }
+            ErrorCode::BackgroundOperationInProgressForNamespace => {
+                "BackgroundOperationInProgressForNamespace"
+            }
             ErrorCode::PrepareConfigsFailedCode => "PrepareConfigsFailedCode",
             ErrorCode::DatabaseDifferCase => "DatabaseDifferCase",
             ErrorCode::ShardKeyTooBig => "ShardKeyTooBig",

--- a/src/gridfs/file.rs
+++ b/src/gridfs/file.rs
@@ -171,10 +171,10 @@ impl File {
     pub fn assert_mode(&self, mode: Mode) -> Result<()> {
         if self.mode != mode {
             return match self.mode {
-                Mode::Read => Err(ArgumentError(String::from("File is open for reading."))),
-                Mode::Write => Err(ArgumentError(String::from("File is open for writing."))),
-                Mode::Closed => Err(ArgumentError(String::from("File is closed."))),
-            };
+                       Mode::Read => Err(ArgumentError(String::from("File is open for reading."))),
+                       Mode::Write => Err(ArgumentError(String::from("File is open for writing."))),
+                       Mode::Closed => Err(ArgumentError(String::from("File is closed."))),
+                   };
         }
         Ok(())
     }
@@ -205,11 +205,13 @@ impl File {
 
                 let mut opts = IndexOptions::new();
                 opts.unique = Some(true);
-                try!(self.gfs.chunks.create_index(doc!{ "files_id" => 1, "n" => 1}, Some(opts)));
+                try!(self.gfs
+                         .chunks
+                         .create_index(doc!{ "files_id" => 1, "n" => 1}, Some(opts)));
             } else {
                 try!(self.gfs
-                    .chunks
-                    .delete_many(doc!{ "files_id" => (self.doc.id.clone()) }, None));
+                         .chunks
+                         .delete_many(doc!{ "files_id" => (self.doc.id.clone()) }, None));
             }
         }
 
@@ -322,8 +324,10 @@ impl File {
                     }
                 };
 
-                let result = arc_gfs.chunks
-                    .find_one(Some(doc!{"files_id" => (id), "n" => (next_chunk_num)}), None);
+                let result = arc_gfs
+                    .chunks
+                    .find_one(Some(doc!{"files_id" => (id), "n" => (next_chunk_num)}),
+                              None);
 
                 match result {
                     Ok(Some(doc)) => {
@@ -618,7 +622,7 @@ impl GfsFile {
             "chunkSize" => (self.chunk_size),
             "length" => (self.len),
             "md5" => (self.md5.to_owned()),
-            "uploadDate" => (self.upload_date.as_ref().unwrap().clone())
+            "uploadDate" => (self.upload_date.unwrap())
         };
 
         if self.name.is_some() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,22 +7,19 @@
 //! The Client is an entry-point to interacting with a MongoDB instance.
 //!
 //! ```no_run
-//! # use mongodb::{Client, ClientOptions, ThreadedClient};
-//! # use mongodb::common::{ReadMode, ReadPreference};
+//! # use mongodb::{Connector, ThreadedClient};
 //! #
-//! // Direct connection to a server. Will not look for other servers in the topology.
-//! let client = Client::connect("localhost", 27017)
+//!
+//! // Create a new Connector to create Clients from.
+//! let connector = Connector::new();
+//!
+//! // Connects to
+//! let client = connector.connect("localhost", 27017)
 //!     .expect("Failed to initialize client.");
 //!
 //! // Connect to a complex server topology, such as a replica set
 //! // or sharded cluster, using a connection string uri.
-//! let client = Client::with_uri("mongodb://localhost:27017,localhost:27018/")
-//!     .expect("Failed to initialize client.");
-//!
-//! // Specify a read preference, and rely on the driver to find secondaries.
-//! let mut options = ClientOptions::new();
-//! options.read_preference = Some(ReadPreference::new(ReadMode::SecondaryPreferred, None));
-//! let client = Client::with_uri_and_options("mongodb://localhost:27017/", options)
+//! let client = connector.connect_with_uri("mongodb://localhost:27017,localhost:27018/")
 //!     .expect("Failed to initialize client.");
 //! ```
 //!
@@ -31,12 +28,13 @@
 //! ```no_run
 //! # #[macro_use] extern crate bson;
 //! # extern crate mongodb;
-//! # use mongodb::{Client, ThreadedClient};
+//! # use mongodb::{Connector, ThreadedClient};
 //! # use mongodb::db::ThreadedDatabase;
 //! # use bson::Bson;
 //! #
 //! # fn main() {
-//! # let client = Client::connect("localhost", 27017).unwrap();
+//! # let connector = Connector::new();
+//! # let client = connector.connect("localhost", 27017).unwrap();
 //! #
 //! let coll = client.db("media").collection("movies");
 //! coll.insert_one(doc!{ "title" => "Back to the Future" }, None).unwrap();
@@ -61,17 +59,19 @@
 //! completion hooks, reacting to command results from the server.
 //!
 //! ```no_run
-//! # use mongodb::{Client, CommandResult, ThreadedClient};
+//! # use mongodb::{Client, CommandResult, Connector, ThreadedClient};
+//! #
 //! fn log_query_duration(client: Client, command_result: &CommandResult) {
-//!     match command_result {
-//!         &CommandResult::Success { duration, .. } => {
+//!     match *command_result {
+//!         CommandResult::Success { duration, .. } => {
 //!             println!("Command took {} nanoseconds.", duration);
 //!         },
 //!         _ => println!("Failed to execute command."),
 //!     }
 //! }
 //!
-//! let mut client = Client::connect("localhost", 27017).unwrap();
+//! let connector = Connector::new();
+//! let mut client = connector.connect("localhost", 27017).unwrap();
 //! client.add_completion_hook(log_query_duration).unwrap();
 //! ```
 //!
@@ -84,17 +84,16 @@
 //!
 //! ## Connection Pooling
 //!
-//! Each server within a MongoDB server set is maintained by the driver with a separate connection
-//! pool. By default, each pool has a maximum of 5 concurrent open connections.
+//! XXX:Rewrite documentation here once r2d2 is integrated.
 
 // Clippy lints
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 #![cfg_attr(feature = "clippy", allow(
     doc_markdown,
-    // allow double_parens for bson/doc macro.
+// allow double_parens for bson/doc macro.
     double_parens,
-    // more explicit than catch-alls.
+// more explicit than catch-alls.
     match_wild_err_arm,
     too_many_arguments,
 ))]
@@ -171,23 +170,18 @@ use std::sync::atomic::{AtomicIsize, Ordering, ATOMIC_ISIZE_INIT};
 
 use apm::Listener;
 use bson::Bson;
-use common::{ReadPreference, ReadMode, WriteConcern};
+use common::{ReadPreference, WriteConcern};
 use connstring::ConnectionString;
 use db::{Database, ThreadedDatabase};
 use error::Error::ResponseError;
 use pool::PooledStream;
-use stream::StreamConnector;
-use topology::{Topology, TopologyDescription, TopologyType, DEFAULT_HEARTBEAT_FREQUENCY_MS,
-DEFAULT_LOCAL_THRESHOLD_MS, DEFAULT_SERVER_SELECTION_TIMEOUT_MS};
+use stream::ConnectMethod;
+use topology::{Topology, TopologyDescription, DEFAULT_HEARTBEAT_FREQUENCY_MS,
+               DEFAULT_LOCAL_THRESHOLD_MS, DEFAULT_SERVER_SELECTION_TIMEOUT_MS};
 use topology::server::Server;
 
 /// Interfaces with a MongoDB server or replica set.
 pub struct ClientInner {
-    /// Indicates how a server should be selected for read operations.
-    pub read_preference: ReadPreference,
-    /// Describes the guarantees provided by MongoDB when reporting the success of a write
-    /// operation.
-    pub write_concern: WriteConcern,
     req_id: Arc<AtomicIsize>,
     topology: Topology,
     listener: Listener,
@@ -195,14 +189,9 @@ pub struct ClientInner {
 }
 
 /// Configuration options for a client.
-#[derive(Default)]
-pub struct ClientOptions {
+pub struct Connector {
     /// File path for command logging.
     pub log_file: Option<String>,
-    /// Client-level server selection preferences for read operations.
-    pub read_preference: Option<ReadPreference>,
-    /// Client-level write guarantees when reporting a write success.
-    pub write_concern: Option<WriteConcern>,
     /// Frequency of server monitor updates; default 10000 ms.
     pub heartbeat_frequency_ms: u32,
     /// Timeout for selecting an appropriate server for operations; default 30000 ms.
@@ -210,61 +199,110 @@ pub struct ClientOptions {
     /// The size of the latency window for selecting suitable servers; default 15 ms.
     pub local_threshold_ms: i64,
     /// Options for how to connect to the server.
-    pub stream_connector: StreamConnector,
+    pub connect_method: ConnectMethod,
 }
 
-impl ClientOptions {
-    /// Creates a new default options struct.
-    pub fn new() -> ClientOptions {
-        ClientOptions {
+impl Default for Connector {
+    fn default() -> Self {
+        Self {
             log_file: None,
-            read_preference: None,
-            write_concern: None,
             heartbeat_frequency_ms: DEFAULT_HEARTBEAT_FREQUENCY_MS,
             server_selection_timeout_ms: DEFAULT_SERVER_SELECTION_TIMEOUT_MS,
             local_threshold_ms: DEFAULT_LOCAL_THRESHOLD_MS,
-            stream_connector: StreamConnector::default(),
+            connect_method: Default::default(),
         }
+    }
+}
+
+impl Connector {
+    /// Creates a new default options struct.
+    pub fn new() -> Self {
+        Default::default()
     }
 
     /// Creates a new options struct with a specified log file.
-    pub fn with_log_file(file: &str) -> ClientOptions {
-        let mut options = ClientOptions::new();
-        options.log_file = Some(String::from(file));
-        options
+    pub fn log_file(&mut self, file: &str) -> &mut Self {
+        self.log_file = Some(file.to_string());
+        self
     }
 
     #[cfg(feature = "ssl")]
     /// Creates a new options struct with a specified SSL certificate and key files.
-    pub fn with_ssl(ca_file: &str,
-                    certificate_file: &str,
-                    key_file: &str,
-                    verify_peer: bool)
-        -> ClientOptions {
-            let mut options = ClientOptions::new();
-            options.stream_connector = StreamConnector::with_ssl(ca_file, certificate_file,
-                                                                 key_file, verify_peer);
-            options
+    pub fn ssl(&mut self,
+               ca_file: &str,
+               certificate_file: &str,
+               key_file: &str,
+               verify_peer: bool)
+               -> &mut Self {
+        self.connect_method =
+            ConnectMethod::with_ssl(ca_file, certificate_file, key_file, verify_peer);
+        self
+    }
+
+    pub fn connect(&self, host: &str, port: u16) -> Result<Client> {
+        self.connect_with_connection_string(ConnectionString::new(host, port))
+    }
+
+    pub fn connect_with_uri(&self, uri: &str) -> Result<Client> {
+        self.connect_with_connection_string(ConnectionString::parse(uri)?)
+    }
+
+    fn connect_with_connection_string(&self,
+                                      connection_string: ConnectionString)
+                                      -> Result<Client> {
+        let listener = Listener::new();
+
+        let file = match self.log_file {
+            Some(ref string) => {
+                let _ = listener.add_start_hook(log_command_started);
+                let _ = listener.add_completion_hook(log_command_completed);
+
+                Some(Mutex::new(OpenOptions::new()
+                                    .write(true)
+                                    .append(true)
+                                    .create(true)
+                                    .open(string)?))
+            }
+            None => None,
+        };
+
+
+        let description = TopologyDescription::new(self.connect_method.clone());
+
+        let client = Arc::new(ClientInner {
+                                  req_id: Arc::new(ATOMIC_ISIZE_INIT),
+                                  topology: Topology::new(connection_string.clone(),
+                                                          Some(description),
+                                                          self.connect_method.clone())?,
+                                  listener: listener,
+                                  log_file: file,
+                              });
+
+        // Fill servers array and set options
+        {
+            let top_description = &client.topology.description;
+            let mut top = top_description.write()?;
+            top.heartbeat_frequency_ms = self.heartbeat_frequency_ms;
+            top.server_selection_timeout_ms = self.server_selection_timeout_ms;
+            top.local_threshold_ms = self.local_threshold_ms;
+
+            for host in &connection_string.hosts {
+                let server = Server::new(client.clone(),
+                                         host.clone(),
+                                         top_description.clone(),
+                                         true,
+                                         self.connect_method.clone());
+
+                top.servers.insert(host.clone(), server);
+            }
         }
+
+        Ok(client)
+
+    }
 }
 
 pub trait ThreadedClient: Sync + Sized {
-    /// Creates a new Client directly connected to a single MongoDB server.
-    fn connect(host: &str, port: u16) -> Result<Self>;
-    /// Creates a new Client directly connected to a single MongoDB server with options.
-    fn connect_with_options(host: &str, port: u16, ClientOptions) -> Result<Self>;
-    /// Creates a new Client connected to a complex topology, such as a
-    /// replica set or sharded cluster.
-    fn with_uri(uri: &str) -> Result<Self>;
-    /// Creates a new Client connected to a complex topology, such as a
-    /// replica set or sharded cluster, with options.
-    fn with_uri_and_options(uri: &str, options: ClientOptions) -> Result<Self>;
-    /// Create a new Client with manual connection configurations.
-    /// `connect` and `with_uri` should generally be used as higher-level constructors.
-    fn with_config(config: ConnectionString,
-                   options: Option<ClientOptions>,
-                   description: Option<TopologyDescription>)
-        -> Result<Self>;
     /// Creates a database representation.
     fn db(&self, db_name: &str) -> Database;
     /// Creates a database representation with custom read and write controls.
@@ -272,7 +310,7 @@ pub trait ThreadedClient: Sync + Sized {
                      db_name: &str,
                      read_preference: Option<ReadPreference>,
                      write_concern: Option<WriteConcern>)
-        -> Database;
+                     -> Database;
     /// Acquires a connection stream from the pool, along with slave_ok and should_send_read_pref.
     fn acquire_stream(&self, read_pref: ReadPreference) -> Result<(PooledStream, bool, bool)>;
     /// Acquires a connection stream from the pool for write operations.
@@ -294,83 +332,6 @@ pub trait ThreadedClient: Sync + Sized {
 pub type Client = Arc<ClientInner>;
 
 impl ThreadedClient for Client {
-    fn connect(host: &str, port: u16) -> Result<Client> {
-        let config = ConnectionString::new(host, port);
-        let mut description = TopologyDescription::new(StreamConnector::Tcp);
-        description.topology_type = TopologyType::Single;
-        Client::with_config(config, None, Some(description))
-    }
-
-    fn connect_with_options(host: &str, port: u16, options: ClientOptions) -> Result<Client> {
-        let config = ConnectionString::new(host, port);
-        let mut description = TopologyDescription::new(options.stream_connector.clone());
-
-        description.topology_type = TopologyType::Single;
-        Client::with_config(config, Some(options), Some(description))
-    }
-
-    fn with_uri(uri: &str) -> Result<Client> {
-        let config = try!(connstring::parse(uri));
-        Client::with_config(config, None, None)
-    }
-
-    fn with_uri_and_options(uri: &str, options: ClientOptions) -> Result<Client> {
-        let config = try!(connstring::parse(uri));
-        Client::with_config(config, Some(options), None)
-    }
-
-    fn with_config(config: ConnectionString,
-                   options: Option<ClientOptions>,
-                   description: Option<TopologyDescription>)
-        -> Result<Client> {
-
-            let client_options = options.unwrap_or_else(ClientOptions::new);
-
-            let rp = client_options.read_preference
-                .unwrap_or_else(|| ReadPreference::new(ReadMode::Primary, None));
-            let wc = client_options.write_concern.unwrap_or_else(WriteConcern::new);
-
-            let listener = Listener::new();
-            let file = match client_options.log_file {
-                Some(string) => {
-                    let _ = listener.add_start_hook(log_command_started);
-                    let _ = listener.add_completion_hook(log_command_completed);
-                    Some(Mutex::new(try!(OpenOptions::new()
-                                         .write(true)
-                                         .append(true)
-                                         .create(true)
-                                         .open(&string))))
-                }
-                None => None,
-            };
-
-            let client = Arc::new(ClientInner {
-                req_id: Arc::new(ATOMIC_ISIZE_INIT),
-                topology: try!(Topology::new(config.clone(), description, client_options.stream_connector.clone())),
-                listener: listener,
-                read_preference: rp,
-                write_concern: wc,
-                log_file: file,
-            });
-
-            // Fill servers array and set options
-            {
-                let top_description = &client.topology.description;
-                let mut top = try!(top_description.write());
-                top.heartbeat_frequency_ms = client_options.heartbeat_frequency_ms;
-                top.server_selection_timeout_ms = client_options.server_selection_timeout_ms;
-                top.local_threshold_ms = client_options.local_threshold_ms;
-
-                for host in &config.hosts {
-                    let server = Server::new(client.clone(), host.clone(), top_description.clone(), true, client_options.stream_connector.clone());
-
-                    top.servers.insert(host.clone(), server);
-                }
-            }
-
-            Ok(client)
-        }
-
     fn db(&self, db_name: &str) -> Database {
         Database::open(self.clone(), db_name, None, None)
     }
@@ -379,15 +340,15 @@ impl ThreadedClient for Client {
                      db_name: &str,
                      read_preference: Option<ReadPreference>,
                      write_concern: Option<WriteConcern>)
-        -> Database {
-            Database::open(self.clone(), db_name, read_preference, write_concern)
-        }
+                     -> Database {
+        Database::open(self.clone(), db_name, read_preference, write_concern)
+    }
 
     fn acquire_stream(&self,
                       read_preference: ReadPreference)
-        -> Result<(PooledStream, bool, bool)> {
-            self.topology.acquire_stream(read_preference)
-        }
+                      -> Result<(PooledStream, bool, bool)> {
+        self.topology.acquire_stream(read_preference)
+    }
 
     fn acquire_write_stream(&self) -> Result<PooledStream> {
         self.topology.acquire_write_stream()
@@ -405,16 +366,17 @@ impl ThreadedClient for Client {
         let res = try!(db.command(doc, CommandType::ListDatabases, None));
         if let Some(&Bson::Array(ref batch)) = res.get("databases") {
             // Extract database names
-            let map = batch.iter()
+            let map = batch
+                .iter()
                 .filter_map(|bdoc| {
-                    if let Bson::Document(ref doc) = *bdoc {
-                        if let Some(&Bson::String(ref name)) = doc.get("name") {
-                            return Some(name.to_owned());
-                        }
-                    }
-                    None
-                })
-            .collect();
+                                if let Bson::Document(ref doc) = *bdoc {
+                                    if let Some(&Bson::String(ref name)) = doc.get("name") {
+                                        return Some(name.to_owned());
+                                    }
+                                }
+                                None
+                            })
+                .collect();
             return Ok(map);
         }
 

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -10,7 +10,7 @@ use bson::oid;
 use common::{ReadPreference, ReadMode};
 use connstring::{ConnectionString, Host};
 use pool::PooledStream;
-use stream::StreamConnector;
+use stream::ConnectMethod;
 
 use rand::{thread_rng, Rng};
 
@@ -64,7 +64,7 @@ pub struct TopologyDescription {
     // The largest set version seen from a primary in the topology.
     max_set_version: Option<i64>,
     compat_error: String,
-    stream_connector: StreamConnector,
+    connect_method: ConnectMethod,
 }
 
 /// Holds status and connection information about a server set.
@@ -102,16 +102,16 @@ impl Default for TopologyDescription {
             compatible: true,
             compat_error: String::new(),
             max_set_version: None,
-            stream_connector: StreamConnector::Tcp,
+            connect_method: ConnectMethod::Tcp,
         }
     }
 }
 
 impl TopologyDescription {
     /// Returns a default, unknown topology description.
-    pub fn new(connector: StreamConnector) -> TopologyDescription {
+    pub fn new(connector: ConnectMethod) -> TopologyDescription {
         let mut description = TopologyDescription::default();
-        description.stream_connector = connector;
+        description.connect_method = connector;
         description
     }
 
@@ -771,7 +771,7 @@ impl TopologyDescription {
                                          host.clone(),
                                          top_arc.clone(),
                                          run_monitor,
-                                         self.stream_connector.clone());
+                                         self.connect_method.clone());
                 self.servers.insert(host.clone(), server);
             }
         }
@@ -782,7 +782,7 @@ impl TopologyDescription {
                                          host.clone(),
                                          top_arc.clone(),
                                          run_monitor,
-                                         self.stream_connector.clone());
+                                         self.connect_method.clone());
                 self.servers.insert(host.clone(), server);
             }
         }
@@ -793,7 +793,7 @@ impl TopologyDescription {
                                          host.clone(),
                                          top_arc.clone(),
                                          run_monitor,
-                                         self.stream_connector.clone());
+                                         self.connect_method.clone());
                 self.servers.insert(host.clone(), server);
             }
         }
@@ -804,7 +804,7 @@ impl Topology {
     /// Returns a new topology with the given configuration and description.
     pub fn new(config: ConnectionString,
                description: Option<TopologyDescription>,
-               connector: StreamConnector)
+               connector: ConnectMethod)
                -> Result<Topology> {
 
         let mut options = description.unwrap_or_else(|| TopologyDescription::new(connector));

--- a/src/topology/monitor.rs
+++ b/src/topology/monitor.rs
@@ -10,7 +10,7 @@ use command_type::CommandType;
 use connstring::{self, Host};
 use cursor::Cursor;
 use pool::ConnectionPool;
-use stream::StreamConnector;
+use stream::ConnectMethod;
 use wire_protocol::flags::OpQueryFlags;
 
 use std::collections::BTreeMap;
@@ -156,27 +156,27 @@ impl IsMasterResult {
         if let Some(&Bson::Array(ref arr)) = doc.get("hosts") {
             result.hosts = arr.iter()
                 .filter_map(|bson| match *bson {
-                    Bson::String(ref s) => connstring::parse_host(s).ok(),
-                    _ => None,
-                })
+                                Bson::String(ref s) => connstring::parse_host(s).ok(),
+                                _ => None,
+                            })
                 .collect();
         }
 
         if let Some(&Bson::Array(ref arr)) = doc.get("passives") {
             result.passives = arr.iter()
                 .filter_map(|bson| match *bson {
-                    Bson::String(ref s) => connstring::parse_host(s).ok(),
-                    _ => None,
-                })
+                                Bson::String(ref s) => connstring::parse_host(s).ok(),
+                                _ => None,
+                            })
                 .collect();
         }
 
         if let Some(&Bson::Array(ref arr)) = doc.get("arbiters") {
             result.arbiters = arr.iter()
                 .filter_map(|bson| match *bson {
-                    Bson::String(ref s) => connstring::parse_host(s).ok(),
-                    _ => None,
-                })
+                                Bson::String(ref s) => connstring::parse_host(s).ok(),
+                                _ => None,
+                            })
                 .collect();
         }
 
@@ -225,7 +225,7 @@ impl Monitor {
                pool: Arc<ConnectionPool>,
                top_description: Arc<RwLock<TopologyDescription>>,
                server_description: Arc<RwLock<ServerDescription>>,
-               connector: StreamConnector)
+               connector: ConnectMethod)
                -> Monitor {
         Monitor {
             client: client,
@@ -379,12 +379,16 @@ impl Monitor {
             self.execute_update();
 
             if let Ok(description) = self.top_description.read() {
-                self.heartbeat_frequency_ms.store(description.heartbeat_frequency_ms as usize,
-                                                  Ordering::SeqCst);
+                self.heartbeat_frequency_ms
+                    .store(description.heartbeat_frequency_ms as usize,
+                           Ordering::SeqCst);
             }
 
             let frequency = self.heartbeat_frequency_ms.load(Ordering::SeqCst) as u64;
-            guard = self.condvar.wait_timeout(guard, Duration::from_millis(frequency)).unwrap().0;
+            guard = self.condvar
+                .wait_timeout(guard, Duration::from_millis(frequency))
+                .unwrap()
+                .0;
         }
     }
 }

--- a/src/topology/server.rs
+++ b/src/topology/server.rs
@@ -5,7 +5,7 @@ use Error::{self, OperationError};
 use bson::oid;
 use connstring::Host;
 use pool::{ConnectionPool, PooledStream};
-use stream::StreamConnector;
+use stream::ConnectMethod;
 
 use std::collections::BTreeMap;
 use std::str::FromStr;
@@ -93,15 +93,15 @@ impl FromStr for ServerType {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self> {
         Ok(match s {
-            "Standalone" => ServerType::Standalone,
-            "Mongos" => ServerType::Mongos,
-            "RSPrimary" => ServerType::RSPrimary,
-            "RSSecondary" => ServerType::RSSecondary,
-            "RSArbiter" => ServerType::RSArbiter,
-            "RSOther" => ServerType::RSOther,
-            "RSGhost" => ServerType::RSGhost,
-            _ => ServerType::Unknown,
-        })
+               "Standalone" => ServerType::Standalone,
+               "Mongos" => ServerType::Mongos,
+               "RSPrimary" => ServerType::RSPrimary,
+               "RSSecondary" => ServerType::RSSecondary,
+               "RSArbiter" => ServerType::RSArbiter,
+               "RSOther" => ServerType::RSOther,
+               "RSGhost" => ServerType::RSGhost,
+               _ => ServerType::Unknown,
+           })
     }
 }
 
@@ -208,7 +208,7 @@ impl Server {
                host: Host,
                top_description: Arc<RwLock<TopologyDescription>>,
                run_monitor: bool,
-               connector: StreamConnector)
+               connector: ConnectMethod)
                -> Server {
         let description = Arc::new(RwLock::new(ServerDescription::new()));
 

--- a/src/wire_protocol/operations.rs
+++ b/src/wire_protocol/operations.rs
@@ -147,12 +147,12 @@ impl Message {
         let header = Header::new_update(total_length, request_id);
 
         Ok(Message::OpUpdate {
-            header: header,
-            namespace: namespace,
-            flags: flags,
-            selector: selector,
-            update: update,
-        })
+               header: header,
+               namespace: namespace,
+               flags: flags,
+               selector: selector,
+               update: update,
+           })
     }
 
     /// Constructs a new message request for an insertion.
@@ -176,11 +176,11 @@ impl Message {
         let header = Header::new_insert(total_length, request_id);
 
         Ok(Message::OpInsert {
-            header: header,
-            flags: flags,
-            namespace: namespace,
-            documents: documents,
-        })
+               header: header,
+               flags: flags,
+               namespace: namespace,
+               documents: documents,
+           })
     }
 
     /// Constructs a new message request for a query.
@@ -215,14 +215,14 @@ impl Message {
         let header = Header::new_query(total_length, request_id);
 
         Ok(Message::OpQuery {
-            header: header,
-            flags: flags,
-            namespace: namespace,
-            number_to_skip: number_to_skip,
-            number_to_return: number_to_return,
-            query: query,
-            return_field_selector: return_field_selector,
-        })
+               header: header,
+               flags: flags,
+               namespace: namespace,
+               number_to_skip: number_to_skip,
+               number_to_return: number_to_return,
+               query: query,
+               return_field_selector: return_field_selector,
+           })
     }
 
     /// Constructs a new "get more" request message.
@@ -462,23 +462,28 @@ impl Message {
             Message::OpReply { .. } => {
                 Err(ArgumentError(String::from("OP_REPLY should not be sent to the client.")))
             }
-            Message::OpUpdate { ref header,
-                                ref namespace,
-                                ref flags,
-                                ref selector,
-                                ref update } => {
-                Message::write_update(buffer, header, namespace, flags, selector, update)
-            }
-            Message::OpInsert { ref header, ref flags, ref namespace, ref documents } => {
-                Message::write_insert(buffer, header, flags, namespace, documents)
-            }
-            Message::OpQuery { ref header,
-                               ref flags,
-                               ref namespace,
-                               number_to_skip,
-                               number_to_return,
-                               ref query,
-                               ref return_field_selector } => {
+            Message::OpUpdate {
+                ref header,
+                ref namespace,
+                ref flags,
+                ref selector,
+                ref update,
+            } => Message::write_update(buffer, header, namespace, flags, selector, update),
+            Message::OpInsert {
+                ref header,
+                ref flags,
+                ref namespace,
+                ref documents,
+            } => Message::write_insert(buffer, header, flags, namespace, documents),
+            Message::OpQuery {
+                ref header,
+                ref flags,
+                ref namespace,
+                number_to_skip,
+                number_to_return,
+                ref query,
+                ref return_field_selector,
+            } => {
                 Message::write_query(buffer,
                                      header,
                                      flags,
@@ -488,9 +493,12 @@ impl Message {
                                      query,
                                      return_field_selector)
             }
-            Message::OpGetMore { ref header, ref namespace, number_to_return, cursor_id } => {
-                Message::write_get_more(buffer, header, namespace, number_to_return, cursor_id)
-            }
+            Message::OpGetMore {
+                ref header,
+                ref namespace,
+                number_to_return,
+                cursor_id,
+            } => Message::write_get_more(buffer, header, namespace, number_to_return, cursor_id),
         }
     }
 

--- a/tests/client/bulk.rs
+++ b/tests/client/bulk.rs
@@ -1,24 +1,24 @@
 use bson::Bson;
 use mongodb::coll::options::WriteModel;
-use mongodb::{Client, ThreadedClient};
+use mongodb::{Connector, ThreadedClient};
 use mongodb::db::ThreadedDatabase;
 
 #[test]
 fn bulk_ordered_insert_only() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-bulk");
     let coll = db.collection("bulk_ordered_insert_only");
     coll.drop().unwrap();
 
     let models = (1..5)
         .map(|i| {
-            WriteModel::InsertOne {
-                document: doc! {
+                 WriteModel::InsertOne {
+                     document: doc! {
         "_id" => (i),
         "x" => (i * 11)
     },
-            }
-        })
+                 }
+             })
         .collect();
 
     coll.bulk_write(models, true);
@@ -45,7 +45,7 @@ fn bulk_ordered_insert_only() {
 
 #[test]
 fn bulk_unordered_insert_only() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-bulk");
     let coll = db.collection("bulk_unordered_insert_only");
 
@@ -53,13 +53,13 @@ fn bulk_unordered_insert_only() {
 
     let models = (1..5)
         .map(|i| {
-            WriteModel::InsertOne {
-                document: doc! {
+                 WriteModel::InsertOne {
+                     document: doc! {
         "_id" => (i),
         "x" => (i * 11)
     },
-            }
-        })
+                 }
+             })
         .collect();
 
     coll.bulk_write(models, false);
@@ -86,67 +86,87 @@ fn bulk_unordered_insert_only() {
 
 #[test]
 fn bulk_ordered_mix() {
-    let models = vec![
-        WriteModel::InsertOne { document: doc! {
+    let models = vec![WriteModel::InsertOne {
+                          document: doc! {
             "_id" => (1),
             "x" => (11)
-        }},
-        WriteModel::InsertOne { document: doc! {
+        },
+                      },
+                      WriteModel::InsertOne {
+                          document: doc! {
             "_id" => (2),
             "x" => (22)
-        }},
-        WriteModel::InsertOne { document: doc! {
+        },
+                      },
+                      WriteModel::InsertOne {
+                          document: doc! {
             "_id" => (3),
             "x" => (33)
-        }},
-        WriteModel::InsertOne { document: doc! {
+        },
+                      },
+                      WriteModel::InsertOne {
+                          document: doc! {
             "_id" => (4),
             "x" => (44)
-        }},
-        WriteModel::ReplaceOne {
-            filter: doc! { "_id" => (3) },
-            replacement: doc! { "x" => (37) },
-            upsert: Some(true),
         },
-        WriteModel::UpdateMany {
-            filter: doc! { "_id" => { "$lt" => (3) } },
-            update: doc! { "$inc" => { "x" => (1) } },
-            upsert: Some(false),
-        },
-        WriteModel::DeleteOne { filter: doc! {
+                      },
+                      WriteModel::ReplaceOne {
+                          filter: doc! { "_id" => (3) },
+                          replacement: doc! { "x" => (37) },
+                          upsert: Some(true),
+                      },
+                      WriteModel::UpdateMany {
+                          filter: doc! { "_id" => { "$lt" => (3) } },
+                          update: doc! { "$inc" => { "x" => (1) } },
+                          upsert: Some(false),
+                      },
+                      WriteModel::DeleteOne {
+                          filter: doc! {
             "_id" => (4)
-        }},
-        WriteModel::InsertOne { document: doc! {
+        },
+                      },
+                      WriteModel::InsertOne {
+                          document: doc! {
             "_id" => (5),
             "x" => (55)
-        }},
-        WriteModel::UpdateOne {
-            filter: doc! { "_id" => (6) },
-            update: doc! { "$set" =>  { "x" => (62) } },
-            upsert: Some(true)
         },
-        WriteModel::InsertOne { document: doc! {
+                      },
+                      WriteModel::UpdateOne {
+                          filter: doc! { "_id" => (6) },
+                          update: doc! { "$set" =>  { "x" => (62) } },
+                          upsert: Some(true),
+                      },
+                      WriteModel::InsertOne {
+                          document: doc! {
             "_id" => (101),
             "x" => ("dalmations")
-        }},
-        WriteModel::InsertOne { document: doc! {
+        },
+                      },
+                      WriteModel::InsertOne {
+                          document: doc! {
             "_id" => (102),
             "x" => ("strawberries")
-        }},
-        WriteModel::InsertOne { document: doc! {
+        },
+                      },
+                      WriteModel::InsertOne {
+                          document: doc! {
             "_id" => (103),
             "x" => ("blueberries")
-        }},
-        WriteModel::InsertOne { document: doc! {
+        },
+                      },
+                      WriteModel::InsertOne {
+                          document: doc! {
             "_id" => (104),
             "x" => ("bananas")
-        }},
-        WriteModel::DeleteMany { filter: doc! {
+        },
+                      },
+                      WriteModel::DeleteMany {
+                          filter: doc! {
             "_id" => { "$gte" => (103) }
-        }},
-    ];
+        },
+                      }];
 
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-bulk");
     let coll = db.collection("bulk_ordered_mix");
     coll.drop().unwrap();

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -1,13 +1,13 @@
 use bson::Bson;
 
-use mongodb::{Client, ThreadedClient};
+use mongodb::{Connector, ThreadedClient};
 use mongodb::db::ThreadedDatabase;
 use mongodb::coll::options::{FindOptions, FindOneAndUpdateOptions, IndexModel, IndexOptions,
                              ReturnDocument};
 
 #[test]
 fn find_sorted() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("find_sorted");
 
@@ -25,7 +25,8 @@ fn find_sorted() {
     let mut opts = FindOptions::new();
     opts.sort = Some(doc! { "title" => 1 });
 
-    let mut cursor = coll.find(None, Some(opts)).expect("Failed to execute find command.");
+    let mut cursor = coll.find(None, Some(opts))
+        .expect("Failed to execute find command.");
     let results = cursor.next_n(3).expect("Failed to retrieve documents.");
 
     // Assert expected titles of documents
@@ -50,7 +51,7 @@ fn find_sorted() {
 
 #[test]
 fn find_and_insert() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("find_and_insert");
 
@@ -58,10 +59,12 @@ fn find_and_insert() {
 
     // Insert document
     let doc = doc! { "title" => "Jaws" };
-    coll.insert_one(doc, None).expect("Failed to insert document");
+    coll.insert_one(doc, None)
+        .expect("Failed to insert document");
 
     // Find document
-    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
+    let mut cursor = coll.find(None, None)
+        .expect("Failed to execute find command.");
     let result = match cursor.next() {
         Some(Ok(res)) => res,
         Some(Err(_)) => panic!("Received error from 'cursor.next()'."),
@@ -79,7 +82,7 @@ fn find_and_insert() {
 
 #[test]
 fn find_and_insert_one() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("find_and_insert_one");
 
@@ -87,10 +90,12 @@ fn find_and_insert_one() {
 
     // Insert document
     let doc = doc! { "title" => "Jaws" };
-    coll.insert_one(doc, None).expect("Failed to insert document");
+    coll.insert_one(doc, None)
+        .expect("Failed to insert document");
 
     // Find single document
-    let result = coll.find_one(None, None).expect("Failed to execute find command.");
+    let result = coll.find_one(None, None)
+        .expect("Failed to execute find command.");
     assert!(result.is_some());
 
     // Assert expected title of document
@@ -102,7 +107,7 @@ fn find_and_insert_one() {
 
 #[test]
 fn find_one_and_delete() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("find_one_and_delete");
 
@@ -125,7 +130,8 @@ fn find_one_and_delete() {
     }
 
     // Validate state of collection
-    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
+    let mut cursor = coll.find(None, None)
+        .expect("Failed to execute find command.");
     let result = match cursor.next() {
         Some(Ok(res)) => res,
         Some(Err(_)) => panic!("Received error from 'cursor.next()'."),
@@ -142,7 +148,7 @@ fn find_one_and_delete() {
 
 #[test]
 fn find_one_and_replace() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("find_one_and_replace");
 
@@ -166,7 +172,8 @@ fn find_one_and_replace() {
     }
 
     // Validate state of collection
-    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
+    let mut cursor = coll.find(None, None)
+        .expect("Failed to execute find command.");
     let results = cursor.next_n(3).expect("Failed to get next 3 from cursor.");
     assert_eq!(3, results.len());
 
@@ -198,7 +205,7 @@ fn find_one_and_replace() {
 
 #[test]
 fn find_one_and_update() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("find_one_and_update");
 
@@ -224,7 +231,8 @@ fn find_one_and_update() {
     }
 
     // Validate state of collection
-    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
+    let mut cursor = coll.find(None, None)
+        .expect("Failed to execute find command.");
     let results = cursor.next_n(3).expect("Failed to get next 3 from cursor.");
     assert_eq!(3, results.len());
 
@@ -239,7 +247,7 @@ fn find_one_and_update() {
 
 #[test]
 fn aggregate() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("aggregate");
 
@@ -262,15 +270,18 @@ fn aggregate() {
     let mut cursor = coll.aggregate(vec![project, unwind, group], None)
         .expect("Failed to execute aggregate command.");
 
-    let results = cursor.next_n(10).expect("Failed to get next 10 from cursor.");
+    let results = cursor
+        .next_n(10)
+        .expect("Failed to get next 10 from cursor.");
     assert_eq!(6, results.len());
 
     // Grab ids from aggregated docs
-    let vec: Vec<_> = results.iter()
+    let vec: Vec<_> = results
+        .iter()
         .filter_map(|bdoc| match bdoc.get("_id") {
-            Some(&Bson::String(ref tag)) => Some(tag.to_owned()),
-            _ => None,
-        })
+                        Some(&Bson::String(ref tag)) => Some(tag.to_owned()),
+                        _ => None,
+                    })
         .collect();
 
     // Validate that all distinct tags were received.
@@ -285,7 +296,7 @@ fn aggregate() {
 
 #[test]
 fn count() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("count");
 
@@ -300,24 +311,28 @@ fn count() {
         vec.push(doc2.clone());
     }
 
-    coll.insert_many(vec, None).expect("Failed to insert documents.");
-    let count_doc1 = coll.count(Some(doc1), None).expect("Failed to execute count.");
+    coll.insert_many(vec, None)
+        .expect("Failed to insert documents.");
+    let count_doc1 = coll.count(Some(doc1), None)
+        .expect("Failed to execute count.");
     assert_eq!(1, count_doc1);
 
-    let count_doc2 = coll.count(Some(doc2), None).expect("Failed to execute count.");
+    let count_doc2 = coll.count(Some(doc2), None)
+        .expect("Failed to execute count.");
     assert_eq!(10, count_doc2);
 
     let count_all = coll.count(None, None).expect("Failed to execute count.");
     assert_eq!(11, count_all);
 
     let no_doc = doc! { "title" => "Houdini" };
-    let count_none = coll.count(Some(no_doc), None).expect("Failed to execute count.");
+    let count_none = coll.count(Some(no_doc), None)
+        .expect("Failed to execute count.");
     assert_eq!(0, count_none);
 }
 
 #[test]
 fn distinct_none() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("distinct_none");
 
@@ -329,13 +344,14 @@ fn distinct_none() {
 
 #[test]
 fn distinct_one() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("distinct_one");
 
     coll.drop().expect("Failed to drop database");
     let doc2 = doc! { "title" => "Back to the Future" };
-    coll.insert_one(doc2, None).expect("Failed to insert document.");
+    coll.insert_one(doc2, None)
+        .expect("Failed to insert document.");
 
     let distinct_titles = coll.distinct("title", None, None)
         .expect("Failed to execute 'distinct'.");
@@ -344,7 +360,7 @@ fn distinct_one() {
 
 #[test]
 fn distinct() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("distinct");
 
@@ -367,18 +383,20 @@ fn distinct() {
         vec.push(doc3.clone());
     }
 
-    coll.insert_many(vec, None).expect("Failed to insert documents.");
+    coll.insert_many(vec, None)
+        .expect("Failed to insert documents.");
 
     // Distinct titles over all documents
     let distinct_titles = coll.distinct("title", None, None)
         .expect("Failed to execute 'distinct'.");
     assert_eq!(3, distinct_titles.len());
 
-    let titles: Vec<_> = distinct_titles.iter()
+    let titles: Vec<_> = distinct_titles
+        .iter()
         .filter_map(|bson| match *bson {
-            Bson::String(ref title) => Some(title.to_owned()),
-            _ => None,
-        })
+                        Bson::String(ref title) => Some(title.to_owned()),
+                        _ => None,
+                    })
         .collect();
 
     assert_eq!(3, titles.len());
@@ -393,11 +411,12 @@ fn distinct() {
 
     assert_eq!(2, distinct_titles.len());
 
-    let titles: Vec<_> = distinct_titles.iter()
+    let titles: Vec<_> = distinct_titles
+        .iter()
         .filter_map(|bson| match *bson {
-            Bson::String(ref title) => Some(title.to_owned()),
-            _ => None,
-        })
+                        Bson::String(ref title) => Some(title.to_owned()),
+                        _ => None,
+                    })
         .collect();
 
     assert_eq!(2, titles.len());
@@ -407,7 +426,7 @@ fn distinct() {
 
 #[test]
 fn insert_many() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("insert_many");
 
@@ -417,10 +436,12 @@ fn insert_many() {
     let doc1 = doc! { "title" => "Jaws" };
     let doc2 = doc! { "title" => "Back to the Future" };
 
-    coll.insert_many(vec![doc1, doc2], None).expect("Failed to insert documents.");
+    coll.insert_many(vec![doc1, doc2], None)
+        .expect("Failed to insert documents.");
 
     // Find documents
-    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
+    let mut cursor = coll.find(None, None)
+        .expect("Failed to execute find command.");
     let results = cursor.next_n(2).expect("Failed to get next 2 from cursor.");
     assert_eq!(2, results.len());
 
@@ -437,7 +458,7 @@ fn insert_many() {
 
 #[test]
 fn delete_one() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("delete_one");
 
@@ -451,8 +472,10 @@ fn delete_one() {
         .expect("Failed to insert documents.");
 
     // Delete document
-    coll.delete_one(doc2.clone(), None).expect("Failed to delete document.");
-    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
+    coll.delete_one(doc2.clone(), None)
+        .expect("Failed to delete document.");
+    let mut cursor = coll.find(None, None)
+        .expect("Failed to execute find command.");
     let result = match cursor.next() {
         Some(Ok(res)) => res,
         Some(Err(_)) => panic!("Received error from 'cursor.next()'."),
@@ -469,7 +492,7 @@ fn delete_one() {
 
 #[test]
 fn delete_many() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("delete_many");
 
@@ -483,8 +506,10 @@ fn delete_many() {
         .expect("Failed to insert documents into collection.");
 
     // Delete document
-    coll.delete_many(doc2.clone(), None).expect("Failed to delete documents.");
-    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
+    coll.delete_many(doc2.clone(), None)
+        .expect("Failed to delete documents.");
+    let mut cursor = coll.find(None, None)
+        .expect("Failed to execute find command.");
     let result = match cursor.next() {
         Some(Ok(res)) => res,
         Some(Err(_)) => panic!("Received error from 'cursor.next()'."),
@@ -501,7 +526,7 @@ fn delete_many() {
 
 #[test]
 fn replace_one() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("replace_one");
 
@@ -516,8 +541,10 @@ fn replace_one() {
         .expect("Failed to insert documents into collection.");
 
     // Replace single document
-    coll.replace_one(doc2.clone(), doc3.clone(), None).expect("Failed to replace document.");
-    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
+    coll.replace_one(doc2.clone(), doc3.clone(), None)
+        .expect("Failed to replace document.");
+    let mut cursor = coll.find(None, None)
+        .expect("Failed to execute find command.");
     let results = cursor.next_n(3).expect("Failed to get next 3 from cursor.");
     assert_eq!(3, results.len());
 
@@ -538,7 +565,7 @@ fn replace_one() {
 
 #[test]
 fn update_one() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("update_one");
 
@@ -555,9 +582,11 @@ fn update_one() {
     // Update single document
     let update = doc! { "$set" => { "director" => "Robert Zemeckis" } };
 
-    coll.update_one(doc2.clone(), update, None).expect("Failed to update document.");
+    coll.update_one(doc2.clone(), update, None)
+        .expect("Failed to update document.");
 
-    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
+    let mut cursor = coll.find(None, None)
+        .expect("Failed to execute find command.");
     let results = cursor.next_n(3).expect("Failed to get next 3 from cursor.");
     assert_eq!(3, results.len());
 
@@ -572,7 +601,7 @@ fn update_one() {
 
 #[test]
 fn update_many() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("update_many");
 
@@ -590,9 +619,11 @@ fn update_many() {
     // Update single document
     let update = doc! { "$set" => { "director" => "Robert Zemeckis" } };
 
-    coll.update_many(doc2.clone(), update, None).expect("Failed to update documents.");
+    coll.update_many(doc2.clone(), update, None)
+        .expect("Failed to update documents.");
 
-    let mut cursor = coll.find(None, None).expect("Failed to execute find command.");
+    let mut cursor = coll.find(None, None)
+        .expect("Failed to execute find command.");
     let results = cursor.next_n(4).expect("Failed to get next 4 from cursor.");
     assert_eq!(4, results.len());
 
@@ -613,7 +644,7 @@ fn update_many() {
 
 #[test]
 fn create_list_drop_indexes() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("create_list_drop_indexes");
 
@@ -681,7 +712,8 @@ fn create_list_drop_indexes() {
 
     assert_eq!(2, results.len());
 
-    coll.drop_index(doc!{ "test" => (-1), "height" => 1 }, None).unwrap();
+    coll.drop_index(doc!{ "test" => (-1), "height" => 1 }, None)
+        .unwrap();
     let mut cursor = coll.list_indexes().unwrap();
     let results = cursor.next_n(5).unwrap();
 
@@ -690,7 +722,7 @@ fn create_list_drop_indexes() {
 
 #[test]
 fn drop_all_indexes() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-coll");
     let coll = db.collection("drop_all_indexes");
 

--- a/tests/client/connstring.rs
+++ b/tests/client/connstring.rs
@@ -1,52 +1,48 @@
-use mongodb::connstring;
+use mongodb::connstring::{self, ConnectionString};
 
 #[test]
 fn valid_uri() {
-    let valid_uris = vec!(
-        "mongodb://localhost",
-        "mongodb://localhost/",
-        "mongodb://localhost/?",
-        "mongodb://localhost:27017",
-        "mongodb://localhost:27017/",
-        "mongodb://localhost:27017/?",
-        "mongodb://127.0.0.1",
-        "mongodb://127.0.0.1/",
-        "mongodb://127.0.0.1/?",
-        "mongodb://127.0.0.1:27017",
-        "mongodb://127.0.0.1:27017/",
-        "mongodb://127.0.0.1:27017/?",
-    );
+    let valid_uris = vec!["mongodb://localhost",
+                          "mongodb://localhost/",
+                          "mongodb://localhost/?",
+                          "mongodb://localhost:27017",
+                          "mongodb://localhost:27017/",
+                          "mongodb://localhost:27017/?",
+                          "mongodb://127.0.0.1",
+                          "mongodb://127.0.0.1/",
+                          "mongodb://127.0.0.1/?",
+                          "mongodb://127.0.0.1:27017",
+                          "mongodb://127.0.0.1:27017/",
+                          "mongodb://127.0.0.1:27017/?"];
 
     for uri in valid_uris {
-        assert!(connstring::parse(uri).is_ok());
+        assert!(ConnectionString::parse(uri).is_ok());
     }
 }
 
 #[test]
 fn invalid_prefix() {
-    let invalid_uris = vec!(
-        "mongodb:/localhost",
-        "mngodb://localhost",
-        "mongodb//localhost",
-        "://localhost",
-        "localhost:27017",
-    );
+    let invalid_uris = vec!["mongodb:/localhost",
+                            "mngodb://localhost",
+                            "mongodb//localhost",
+                            "://localhost",
+                            "localhost:27017"];
 
     for uri in invalid_uris {
-        assert!(connstring::parse(uri).is_err());
+        assert!(ConnectionString::parse(uri).is_err());
     }
 }
 
 #[test]
 fn optional_user_password() {
     let uri = "mongodb://local:27017";
-    assert!(connstring::parse(uri).is_ok());
+    assert!(ConnectionString::parse(uri).is_ok());
 }
 
 #[test]
 fn parse_user_password() {
     let uri = "mongodb://user:password@local:27017";
-    let connstr = connstring::parse(uri).unwrap();
+    let connstr = ConnectionString::parse(uri).unwrap();
     assert_eq!("user", connstr.user.unwrap());
     assert_eq!("password", connstr.password.unwrap());
 }
@@ -54,7 +50,7 @@ fn parse_user_password() {
 #[test]
 fn hash_in_username() {
     let uri = "mongodb://us#er:password@local:27017";
-    let connstr = connstring::parse(uri).unwrap();
+    let connstr = ConnectionString::parse(uri).unwrap();
     assert_eq!("us#er", connstr.user.unwrap());
     assert_eq!("password", connstr.password.unwrap());
 }
@@ -62,26 +58,24 @@ fn hash_in_username() {
 #[test]
 fn hash_in_password() {
     let uri = "mongodb://user:pass#word@local:27017";
-    let connstr = connstring::parse(uri).unwrap();
+    let connstr = ConnectionString::parse(uri).unwrap();
     assert_eq!("user", connstr.user.unwrap());
     assert_eq!("pass#word", connstr.password.unwrap());
 }
 
 #[test]
 fn required_host() {
-    let missing_hosts = vec!(
-        "mongodb://",
-        "mongodb:///fake",
-        "mongodb://?opt",
-        "mongodb:///?opt",
-        );
+    let missing_hosts = vec!["mongodb://",
+                             "mongodb:///fake",
+                             "mongodb://?opt",
+                             "mongodb:///?opt"];
 
     for uri in missing_hosts {
-        assert!(connstring::parse(uri).is_err());
+        assert!(ConnectionString::parse(uri).is_err());
     }
 
     let good_host = "mongodb://local";
-    let result = connstring::parse(good_host);
+    let result = ConnectionString::parse(good_host);
     assert!(result.is_ok());
 
     let connstr = result.unwrap();
@@ -92,7 +86,7 @@ fn required_host() {
 #[test]
 fn replica_sets() {
     let uri = "mongodb://local:27017,remote:27018,japan:30000";
-    let result = connstring::parse(uri);
+    let result = ConnectionString::parse(uri);
     assert!(result.is_ok());
 
     let connstr = result.unwrap();
@@ -108,14 +102,14 @@ fn replica_sets() {
 #[test]
 fn default_port_on_single_host() {
     let uri = "mongodb://local/";
-    let connstring = connstring::parse(uri).unwrap();
+    let connstring = ConnectionString::parse(uri).unwrap();
     assert_eq!(connstring::DEFAULT_PORT, connstring.hosts[0].port);
 }
 
 #[test]
 fn default_port_on_replica_set() {
     let uri = "mongodb://local,remote/";
-    let connstring = connstring::parse(uri).unwrap();
+    let connstring = ConnectionString::parse(uri).unwrap();
     assert_eq!(connstring::DEFAULT_PORT, connstring.hosts[0].port);
     assert_eq!(connstring::DEFAULT_PORT, connstring.hosts[1].port);
 }
@@ -124,8 +118,8 @@ fn default_port_on_replica_set() {
 fn default_database() {
     let uri1 = "mongodb://local/";
     let uri2 = "mongodb://local";
-    let connstring1 = connstring::parse(uri1).unwrap();
-    let connstring2 = connstring::parse(uri2).unwrap();
+    let connstring1 = ConnectionString::parse(uri1).unwrap();
+    let connstring2 = ConnectionString::parse(uri2).unwrap();
     assert_eq!("test", connstring1.database.unwrap());
     assert_eq!("test", connstring2.database.unwrap());
 }
@@ -133,15 +127,17 @@ fn default_database() {
 #[test]
 fn overridable_database() {
     let uri = "mongodb://localhost,a,x:34343,b/tools";
-    let connstring = connstring::parse(uri).unwrap();
+    let connstring = ConnectionString::parse(uri).unwrap();
     assert_eq!("tools", connstring.database.unwrap());
 }
 
 #[test]
 fn query_separators() {
     for delim in &[";", "&"] {
-        let uri = format!("mongodb://rust/?replicaSet=myreplset{}slaveOk=true{}x=1", delim, delim);
-        let result = connstring::parse(&uri);
+        let uri = format!("mongodb://rust/?replicaSet=myreplset{}slaveOk=true{}x=1",
+                          delim,
+                          delim);
+        let result = ConnectionString::parse(&uri);
         assert!(result.is_ok());
 
         let connstr = result.unwrap();
@@ -154,13 +150,11 @@ fn query_separators() {
 
 #[test]
 fn read_pref_tags() {
-    let pref_set = vec!(
-        vec!("dc:ny"),
-        vec!("dc:ny,rack:1"),
-        vec!("dc:ny,rack:1", "dc:sf,rack:2"),
-        vec!("dc:ny,rack:1", "dc:sf,rack:2", ""),
-        vec!("dc:ny,rack:1", "dc:ny", ""),
-        );
+    let pref_set = vec![vec!["dc:ny"],
+                        vec!["dc:ny,rack:1"],
+                        vec!["dc:ny,rack:1", "dc:sf,rack:2"],
+                        vec!["dc:ny,rack:1", "dc:sf,rack:2", ""],
+                        vec!["dc:ny,rack:1", "dc:ny", ""]];
 
     for delim in &["&", ";"] {
         for prefs in &pref_set {
@@ -169,7 +163,7 @@ fn read_pref_tags() {
                 uri = format!("{}{}readPreferenceTags={}", uri, delim, pref);
             }
 
-            let connstr = connstring::parse(&uri).unwrap();
+            let connstr = ConnectionString::parse(&uri).unwrap();
             let options = connstr.options.unwrap();
             assert_eq!(options.read_pref_tags.len(), prefs.len());
 
@@ -183,7 +177,7 @@ fn read_pref_tags() {
 #[test]
 fn unix_domain_socket_single() {
     let uri = "mongodb:///tmp/mongodb-27017.sock/?safe=false";
-    let connstr = connstring::parse(uri).unwrap();
+    let connstr = ConnectionString::parse(uri).unwrap();
     assert!(connstr.hosts[0].has_ipc());
     assert_eq!("/tmp/mongodb-27017.sock", connstr.hosts[0].ipc);
 }
@@ -191,7 +185,7 @@ fn unix_domain_socket_single() {
 #[test]
 fn unix_domain_socket_auth() {
     let uri = "mongodb://user:password@/tmp/mongodb-27017.sock/?safe=false";
-    let connstr = connstring::parse(uri).unwrap();
+    let connstr = ConnectionString::parse(uri).unwrap();
     let options = connstr.options.unwrap();
     assert!(connstr.hosts[0].has_ipc());
     assert_eq!("/tmp/mongodb-27017.sock", connstr.hosts[0].ipc);
@@ -204,7 +198,7 @@ fn unix_domain_socket_auth() {
 fn unix_domain_socket_replica_set() {
     let uri = "mongodb://user:password@/tmp/mongodb-27017.sock,/tmp/mongodb-27018.\
                sock/dbname?safe=false";
-    let connstr = connstring::parse(uri).unwrap();
+    let connstr = ConnectionString::parse(uri).unwrap();
     let options = connstr.options.unwrap();
     assert!(connstr.hosts[0].has_ipc());
     assert!(connstr.hosts[1].has_ipc());
@@ -219,7 +213,7 @@ fn unix_domain_socket_replica_set() {
 #[test]
 fn ipv6() {
     let uri = "mongodb://[::1]:27017/test";
-    let connstr = connstring::parse(uri).unwrap();
+    let connstr = ConnectionString::parse(uri).unwrap();
     assert_eq!(1, connstr.hosts.len());
     assert_eq!("::1", connstr.hosts[0].host_name);
     assert_eq!(27017, connstr.hosts[0].port);
@@ -228,8 +222,9 @@ fn ipv6() {
 #[test]
 fn full() {
     let opts = "?replicaSet=myreplset&journal=true&w=2&wtimeoutMS=50";
-    let uri = format!("mongodb://u#ser:pas#s@local,remote:27018,japan:27019/rocksdb{}", opts);
-    let connstr = connstring::parse(&uri).unwrap();
+    let uri = format!("mongodb://u#ser:pas#s@local,remote:27018,japan:27019/rocksdb{}",
+                      opts);
+    let connstr = ConnectionString::parse(&uri).unwrap();
     assert_eq!("u#ser", connstr.user.unwrap());
     assert_eq!("pas#s", connstr.password.unwrap());
     assert_eq!("rocksdb", connstr.database.unwrap());

--- a/tests/client/crud_spec/framework.rs
+++ b/tests/client/crud_spec/framework.rs
@@ -245,7 +245,7 @@ macro_rules! run_suite {
     ( $file:expr, $coll:expr ) => {{
         let json = Value::from_file($file).unwrap();
         let suite = json.get_suite().unwrap();
-        let client =  Client::connect("localhost", 27017).unwrap();
+        let client =  Connector::new().connect("localhost", 27017).unwrap();
         let db = client.db("test");
         let coll = db.collection($coll);
 

--- a/tests/client/crud_spec/read.rs
+++ b/tests/client/crud_spec/read.rs
@@ -2,7 +2,7 @@ use bson::Bson;
 use json::crud::arguments::Arguments;
 use json::crud::reader::SuiteContainer;
 use json::eq::{self, NumEq};
-use mongodb::{Client, ThreadedClient};
+use mongodb::{Connector, ThreadedClient};
 use mongodb::coll::options::{InsertManyOptions, ReplaceOptions, UpdateOptions};
 use mongodb::db::ThreadedDatabase;
 use serde_json::Value;

--- a/tests/client/crud_spec/write.rs
+++ b/tests/client/crud_spec/write.rs
@@ -2,7 +2,7 @@ use bson::Bson;
 use json::crud::arguments::Arguments;
 use json::crud::reader::SuiteContainer;
 use json::eq::{self, NumEq};
-use mongodb::{Client, ThreadedClient};
+use mongodb::{Connector, ThreadedClient};
 use mongodb::coll::options::{InsertManyOptions, ReplaceOptions, UpdateOptions};
 use mongodb::db::ThreadedDatabase;
 use serde_json::Value;

--- a/tests/client/cursor.rs
+++ b/tests/client/cursor.rs
@@ -1,6 +1,6 @@
 use bson::{Bson, Document};
 
-use mongodb::{Client, CommandType, ThreadedClient};
+use mongodb::{CommandType, Connector, ThreadedClient};
 use mongodb::common::{ReadMode, ReadPreference};
 use mongodb::coll::options::FindOptions;
 use mongodb::db::ThreadedDatabase;
@@ -9,7 +9,7 @@ use mongodb::wire_protocol::flags::OpQueryFlags;
 
 #[test]
 fn cursor_features() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-cursor");
     let coll = db.collection("cursor_test");
 
@@ -43,7 +43,9 @@ fn cursor_features() {
         Err(s) => panic!("{}", s),
     };
 
-    let batch = cursor.drain_current_batch().expect("Failed to get current batch from cursor.");
+    let batch = cursor
+        .drain_current_batch()
+        .expect("Failed to get current batch from cursor.");
 
     assert_eq!(batch.len(), 3 as usize);
 

--- a/tests/client/db.rs
+++ b/tests/client/db.rs
@@ -1,12 +1,12 @@
 use bson::{self, Bson};
-use mongodb::{Client, ThreadedClient};
+use mongodb::{Connector, ThreadedClient};
 use mongodb::db::ThreadedDatabase;
 use mongodb::db::options::CreateUserOptions;
 use mongodb::db::roles::{AllDatabaseRole, SingleDatabaseRole, Role};
 
 #[test]
 fn create_collection() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-db-create_collection");
     db.drop_database().unwrap();
 
@@ -48,7 +48,7 @@ fn create_collection() {
 
 #[test]
 fn list_collections() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-db-list_collections");
 
     db.drop_database().expect("Failed to drop database");
@@ -96,7 +96,7 @@ fn list_collections() {
 
 #[test]
 fn create_and_get_users() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-db-create_and_get_users");
     db.drop_database().unwrap();
     db.drop_all_users(None).unwrap();
@@ -122,7 +122,8 @@ fn create_and_get_users() {
         write_concern: None,
     };
 
-    db.create_user("saghm", "ilikepuns!", Some(saghm_options)).unwrap();
+    db.create_user("saghm", "ilikepuns!", Some(saghm_options))
+        .unwrap();
 
     db.create_user("val", "ilikeangularjs!", None).unwrap();
 
@@ -181,7 +182,7 @@ fn create_and_get_users() {
 
 #[test]
 fn get_version() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-db-get_version");
     let _ = db.version().unwrap();
 }

--- a/tests/client/mod.rs
+++ b/tests/client/mod.rs
@@ -9,24 +9,30 @@ mod gridfs;
 mod wire_protocol;
 
 use bson;
-use mongodb::{Client, ThreadedClient};
+use mongodb::{Connector, ThreadedClient};
 use mongodb::db::ThreadedDatabase;
 use std::thread;
 
 #[test]
 fn is_master() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let res = client.is_master().expect("Failed to execute is_master.");
     assert!(res);
 }
 
 #[test]
 fn database_names() {
-    let client = Client::connect("localhost", 27017).unwrap();
-    client.drop_database("test-client-mod-database_names").expect("Failed to drop database");
-    client.drop_database("test-client-mod-database_names_2").expect("Failed to drop database");
+    let client = Connector::new().connect("localhost", 27017).unwrap();
+    client
+        .drop_database("test-client-mod-database_names")
+        .expect("Failed to drop database");
+    client
+        .drop_database("test-client-mod-database_names_2")
+        .expect("Failed to drop database");
 
-    let base_results = client.database_names().expect("Failed to execute database_names.");
+    let base_results = client
+        .database_names()
+        .expect("Failed to execute database_names.");
 
     assert!(base_results.contains(&"admin".to_owned()));
     assert!(base_results.contains(&"local".to_owned()));
@@ -44,7 +50,9 @@ fn database_names() {
         .expect("Failed to insert placeholder document into collection");
 
     // Check new dbs
-    let results = client.database_names().expect("Failed to execute database_names.");
+    let results = client
+        .database_names()
+        .expect("Failed to execute database_names.");
     assert!(results.contains(&"admin".to_owned()));
     assert!(results.contains(&"local".to_owned()));
     assert!(results.contains(&"test-client-mod-database_names".to_owned()));
@@ -53,14 +61,20 @@ fn database_names() {
 
 #[test]
 fn is_sync() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let client1 = client.clone();
     let client2 = client.clone();
 
-    client.drop_database("test-client-mod-is_sync").expect("failed to drop database");
-    client.drop_database("test-client-mod-is_sync_2").expect("failed to drop database");
+    client
+        .drop_database("test-client-mod-is_sync")
+        .expect("failed to drop database");
+    client
+        .drop_database("test-client-mod-is_sync_2")
+        .expect("failed to drop database");
 
-    let base_results = client.database_names().expect("Failed to execute database_names.");
+    let base_results = client
+        .database_names()
+        .expect("Failed to execute database_names.");
 
     assert!(base_results.contains(&"admin".to_owned()));
     assert!(base_results.contains(&"local".to_owned()));
@@ -73,7 +87,9 @@ fn is_sync() {
         db.collection("test1")
             .insert_one(bson::Document::new(), None)
             .expect("Failed to insert placeholder document into collection");
-        let results = client1.database_names().expect("Failed to execute database_names.");
+        let results = client1
+            .database_names()
+            .expect("Failed to execute database_names.");
         assert!(results.contains(&"test-client-mod-is_sync".to_owned()));
     });
 
@@ -82,7 +98,9 @@ fn is_sync() {
         db.collection("test2")
             .insert_one(bson::Document::new(), None)
             .expect("Failed to insert placeholder document into collection");
-        let results = client2.database_names().expect("Failed to execute database_names.");
+        let results = client2
+            .database_names()
+            .expect("Failed to execute database_names.");
         assert!(results.contains(&"test-client-mod-is_sync_2".to_owned()));
     });
 
@@ -90,7 +108,9 @@ fn is_sync() {
     let _ = child2.join();
 
     // Check new dbs
-    let results = client.database_names().expect("Failed to execute database_names.");
+    let results = client
+        .database_names()
+        .expect("Failed to execute database_names.");
     assert!(results.contains(&"admin".to_owned()));
     assert!(results.contains(&"local".to_owned()));
     assert!(results.contains(&"test-client-mod-is_sync".to_owned()));

--- a/tests/client/wire_protocol.rs
+++ b/tests/client/wire_protocol.rs
@@ -1,5 +1,5 @@
 use bson::{Bson, Document};
-use mongodb::{Client, ThreadedClient};
+use mongodb::{Connector, ThreadedClient};
 use mongodb::db::ThreadedDatabase;
 use mongodb::wire_protocol::flags::{OpInsertFlags, OpQueryFlags, OpUpdateFlags};
 use mongodb::wire_protocol::operations::Message;
@@ -7,10 +7,10 @@ use std::net::TcpStream;
 
 #[test]
 fn insert_single_key_doc() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-wire_protocol-insert_single_key_doc");
     db.drop_database().unwrap();
-    
+
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
             let doc = doc! { "foo" => 42.0 };
@@ -68,7 +68,7 @@ fn insert_single_key_doc() {
 
 #[test]
 fn insert_multi_key_doc() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-wire_protocol-insert_multi_key_doc");
     db.drop_database().unwrap();
 
@@ -137,7 +137,7 @@ fn insert_multi_key_doc() {
 
 #[test]
 fn insert_docs() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-wire_protocol-insert_docs");
     db.drop_database().unwrap();
 
@@ -217,7 +217,7 @@ fn insert_docs() {
 
 #[test]
 fn insert_update_then_query() {
-    let client = Client::connect("localhost", 27017).unwrap();
+    let client = Connector::new().connect("localhost", 27017).unwrap();
     let db = client.db("test-client-wire_protocol-insert_update_then_query");
     db.drop_database().unwrap();
 

--- a/tests/json/crud/arguments.rs
+++ b/tests/json/crud/arguments.rs
@@ -76,10 +76,10 @@ impl Arguments {
         }
 
         Ok(Arguments::Aggregate {
-            pipeline: docs,
-            options: options,
-            out: out,
-        })
+               pipeline: docs,
+               options: options,
+               out: out,
+           })
     }
 
     pub fn count_from_json(object: &Map<String, Value>) -> Arguments {
@@ -102,9 +102,9 @@ impl Arguments {
                                    "`delete` requires document");
 
         Ok(Arguments::Delete {
-            filter: document,
-            many: many,
-        })
+               filter: document,
+               many: many,
+           })
     }
 
     pub fn distinct_from_json(object: &Map<String, Value>) -> Result<Arguments, String> {
@@ -118,9 +118,9 @@ impl Arguments {
         };
 
         Ok(Arguments::Distinct {
-            field_name: field_name,
-            filter: filter,
-        })
+               field_name: field_name,
+               filter: filter,
+           })
     }
 
     pub fn find_from_json(object: &Map<String, Value>) -> Arguments {
@@ -145,27 +145,29 @@ impl Arguments {
                                  "`find_one_and_delete` requires filter document");
 
         Ok(Arguments::FindOneAndDelete {
-            filter: filter,
-            options: options,
-        })
+               filter: filter,
+               options: options,
+           })
     }
 
-    pub fn find_one_and_replace_from_json(object: &Map<String, Value>) -> Result<Arguments, String> {
+    pub fn find_one_and_replace_from_json(object: &Map<String, Value>)
+                                          -> Result<Arguments, String> {
         let options = FindOneAndUpdateOptions::from_json(object);
 
         let filter = val_or_err!(object.get("filter").map(Value::clone).map(Into::into),
                                  Some(Bson::Document(doc)) => doc,
                                  "`find_one_and_update` requires filter document");
 
-        let replacement = val_or_err!(object.get("replacement").map(Value::clone).map(Into::into),
+        let replacement =
+            val_or_err!(object.get("replacement").map(Value::clone).map(Into::into),
                                  Some(Bson::Document(doc)) => doc,
                                  "`find_one_and_replace` requires replacement document");
 
         Ok(Arguments::FindOneAndReplace {
-            filter: filter,
-            replacement: replacement,
-            options: options,
-        })
+               filter: filter,
+               replacement: replacement,
+               options: options,
+           })
     }
 
     pub fn find_one_and_update_from_json(object: &Map<String, Value>) -> Result<Arguments, String> {
@@ -180,10 +182,10 @@ impl Arguments {
                                  "`find_one_and_update` requires update document");
 
         Ok(Arguments::FindOneAndUpdate {
-            filter: filter,
-            update: update,
-            options: options,
-        })
+               filter: filter,
+               update: update,
+               options: options,
+           })
     }
 
     pub fn insert_many_from_json(object: &Map<String, Value>) -> Result<Arguments, String> {
@@ -224,10 +226,10 @@ impl Arguments {
                                 Some(Bson::Boolean(b)) => b);
 
         Ok(Arguments::ReplaceOne {
-            filter: filter,
-            replacement: replacement,
-            upsert: upsert,
-        })
+               filter: filter,
+               replacement: replacement,
+               upsert: upsert,
+           })
     }
 
     pub fn update_from_json(object: &Map<String, Value>, many: bool) -> Result<Arguments, String> {
@@ -243,10 +245,10 @@ impl Arguments {
                                 Some(Bson::Boolean(b)) => b);
 
         Ok(Arguments::Update {
-            filter: filter,
-            update: update,
-            upsert: upsert,
-            many: many,
-        })
+               filter: filter,
+               update: update,
+               upsert: upsert,
+               many: many,
+           })
     }
 }

--- a/tests/json/crud/options.rs
+++ b/tests/json/crud/options.rs
@@ -63,7 +63,8 @@ impl FromValue for FindOneAndDeleteOptions {
     fn from_json(object: &Map<String, Value>) -> FindOneAndDeleteOptions {
         let mut options = FindOneAndDeleteOptions::new();
 
-        if let Some(Bson::Document(projection)) = object.get("projection").map(Value::clone).map(Into::into) {
+        if let Some(Bson::Document(projection)) =
+            object.get("projection").map(Value::clone).map(Into::into) {
             options.projection = Some(projection);
         }
 
@@ -79,11 +80,16 @@ impl FromValue for FindOneAndUpdateOptions {
     fn from_json(object: &Map<String, Value>) -> FindOneAndUpdateOptions {
         let mut options = FindOneAndUpdateOptions::new();
 
-        if let Some(Bson::Document(projection)) = object.get("projection").map(Value::clone).map(Into::into) {
+        if let Some(Bson::Document(projection)) =
+            object.get("projection").map(Value::clone).map(Into::into) {
             options.projection = Some(projection);
         }
 
-        if let Some(Bson::String(s)) = object.get("returnDocument").map(Value::clone).map(Into::into) {
+        if let Some(Bson::String(s)) =
+            object
+                .get("returnDocument")
+                .map(Value::clone)
+                .map(Into::into) {
             match s.as_ref() {
                 "After" => options.return_document = Some(ReturnDocument::After),
                 "Before" => options.return_document = Some(ReturnDocument::Before),
@@ -96,7 +102,8 @@ impl FromValue for FindOneAndUpdateOptions {
             options.sort = Some(sort);
         }
 
-        if let Some(Bson::Boolean(upsert)) = object.get("upsert").map(Value::clone).map(Into::into) {
+        if let Some(Bson::Boolean(upsert)) =
+            object.get("upsert").map(Value::clone).map(Into::into) {
             options.upsert = Some(upsert);
         }
 

--- a/tests/json/crud/outcome.rs
+++ b/tests/json/crud/outcome.rs
@@ -22,9 +22,9 @@ impl Outcome {
             Some(&Value::Object(ref obj)) => obj.clone(),
             _ => {
                 return Ok(Outcome {
-                    result: result,
-                    collection: None,
-                })
+                              result: result,
+                              collection: None,
+                          })
             }
         };
 
@@ -52,8 +52,8 @@ impl Outcome {
         };
 
         Ok(Outcome {
-            result: result,
-            collection: Some(collection),
-        })
+               result: result,
+               collection: Some(collection),
+           })
     }
 }

--- a/tests/json/crud/reader.rs
+++ b/tests/json/crud/reader.rs
@@ -62,9 +62,9 @@ impl Test {
         };
 
         Ok(Test {
-            operation: args,
-            outcome: outcome,
-        })
+               operation: args,
+               outcome: outcome,
+           })
     }
 }
 
@@ -132,8 +132,8 @@ impl SuiteContainer for Value {
         let tests = try!(get_tests(&object));
 
         Ok(Suite {
-            data: data,
-            tests: tests,
-        })
+               data: data,
+               tests: tests,
+           })
     }
 }

--- a/tests/json/eq.rs
+++ b/tests/json/eq.rs
@@ -74,4 +74,3 @@ pub fn bson_eq(b1: &Bson, b2: &Bson) -> bool {
         Bson::Symbol(ref s1) => var_match!(*b2, Bson::Symbol(ref s2) => s1 == s2),
     }
 }
-

--- a/tests/json/sdam/outcome.rs
+++ b/tests/json/sdam/outcome.rs
@@ -56,9 +56,9 @@ impl Outcome {
         };
 
         Ok(Outcome {
-            servers: servers,
-            set_name: set_name,
-            ttype: ttype,
-        })
+               servers: servers,
+               set_name: set_name,
+               ttype: ttype,
+           })
     }
 }

--- a/tests/json/sdam/reader.rs
+++ b/tests/json/sdam/reader.rs
@@ -22,9 +22,9 @@ impl Phase {
                                   "No `outcome` object found.");
 
         Ok(Phase {
-            operation: operation,
-            outcome: outcome,
-        })
+               operation: operation,
+               outcome: outcome,
+           })
     }
 }
 
@@ -79,8 +79,8 @@ impl SuiteContainer for Value {
 
         let phases = try!(get_phases(&object));
         Ok(Suite {
-            uri: uri,
-            phases: phases,
-        })
+               uri: uri,
+               phases: phases,
+           })
     }
 }

--- a/tests/json/sdam/responses.rs
+++ b/tests/json/sdam/responses.rs
@@ -11,12 +11,13 @@ impl Responses {
         let mut data = Vec::new();
 
         for json in array {
-            let inner_array = val_or_err!(*json,
+            let inner_array =
+                val_or_err!(*json,
                                           Value::Array(ref arr) => arr,
                                           "`responses` must be an array of arrays.");
 
             if inner_array.len() != 2 {
-                return Err(String::from("Response item must contain the host string and ismaster object."));
+                return Err(String::from("Response item must contain the host string and ismaster object.",),);
             }
 
             let host = val_or_err!(

--- a/tests/json/server_selection/reader.rs
+++ b/tests/json/server_selection/reader.rs
@@ -59,22 +59,26 @@ impl SuiteContainer for Value {
 
         let write = operation == "write";
 
-        let read_preference = val_or_err!(object.get("read_preference"),
+        let read_preference =
+            val_or_err!(object.get("read_preference"),
                                           Some(&Value::Object(ref object)) =>
                                           try!(ReadPreference::from_json(object)),
                                           "suite requires a read_preference object.");
 
-        let in_latency_window = val_or_err!(object.get("in_latency_window"),
+        let in_latency_window =
+            val_or_err!(object.get("in_latency_window"),
                                            Some(&Value::Array(ref array)) =>
                                            try!(get_server_array(array)),
                                            "suite requires an in_latency_window array.");
 
-        let suitable_servers = val_or_err!(object.get("suitable_servers"),
+        let suitable_servers =
+            val_or_err!(object.get("suitable_servers"),
                                            Some(&Value::Array(ref array)) =>
                                            try!(get_server_array(array)),
                                            "suite requires a suitable_servers array.");
 
-        let topology_obj = val_or_err!(object.get("topology_description"),
+        let topology_obj =
+            val_or_err!(object.get("topology_description"),
                                        Some(&Value::Object(ref obj)) => obj,
                                        "suite requires a topology_description object.");
 
@@ -88,11 +92,11 @@ impl SuiteContainer for Value {
                                 "topology requires a type");
 
         Ok(Suite {
-            in_latency_window: in_latency_window,
-            write: write,
-            read_preference: read_preference,
-            suitable_servers: suitable_servers,
-            topology_description: TopologyDescription::new(top_servers, ttype),
-        })
+               in_latency_window: in_latency_window,
+               write: write,
+               read_preference: read_preference,
+               suitable_servers: suitable_servers,
+               topology_description: TopologyDescription::new(top_servers, ttype),
+           })
     }
 }

--- a/tests/json/server_selection/server.rs
+++ b/tests/json/server_selection/server.rs
@@ -32,8 +32,9 @@ impl Server {
                     Value::String(val) => {
                         tags.insert(key, val);
                     }
-                    _ => return Err(
-                        String::from("server must have tags that are string => string maps.")),
+                    _ => {
+                        return Err(String::from("server must have tags that are string => string maps.",),)
+                    }
                 }
             }
         }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,9 +3,9 @@
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 #![cfg_attr(feature = "clippy", allow(
     doc_markdown,
-    // allow double_parens for bson/doc macro.
+// allow double_parens for bson/doc macro.
     double_parens,
-    // more explicit than catch-alls.
+// more explicit than catch-alls.
     match_wild_err_arm,
     too_many_arguments,
 ))]

--- a/tests/sdam/single.rs
+++ b/tests/sdam/single.rs
@@ -1,4 +1,4 @@
-use mongodb::stream::StreamConnector;
+use mongodb::stream::ConnectMethod;
 use mongodb::topology::{TopologyDescription, TopologyType};
 
 use std::fs;
@@ -15,7 +15,7 @@ fn sdam_single() {
         let path2 = path.unwrap().path();
         let filename = path2.to_string_lossy();
         if filename.ends_with(".json") {
-            let mut description = TopologyDescription::new(StreamConnector::default());
+            let mut description = TopologyDescription::new(ConnectMethod::default());
             description.topology_type = TopologyType::Single;
             run_suite(&filename, Some(description))
         }

--- a/tests/ssl/mod.rs
+++ b/tests/ssl/mod.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use mongodb::{Client, ClientOptions, ThreadedClient};
+use mongodb::{Connector, ThreadedClient};
 use mongodb::db::ThreadedDatabase;
 
 #[test]
@@ -9,11 +9,13 @@ fn ssl_connect_and_insert() {
     test_path.push("tests");
     test_path.push("ssl");
 
-    let options = ClientOptions::with_ssl(test_path.join("ca.pem").to_str().unwrap(),
-                                          test_path.join("client.crt").to_str().unwrap(),
-                                          test_path.join("client.key").to_str().unwrap(),
-                                          false);
-    let client = Client::connect_with_options("127.0.0.1", 27018, options).unwrap();
+    let client = Connector::new()
+        .ssl(test_path.join("ca.pem").to_str().unwrap(),
+             test_path.join("client.crt").to_str().unwrap(),
+             test_path.join("client.key").to_str().unwrap(),
+             false)
+        .connect("127.0.0.1", 27018)
+        .unwrap();
     let db = client.db("test");
     let coll = db.collection("stuff");
 

--- a/tests/ssl/mod.rs
+++ b/tests/ssl/mod.rs
@@ -10,11 +10,11 @@ fn ssl_connect_and_insert() {
     test_path.push("ssl");
 
     let client = Connector::new()
-        .ssl(test_path.join("ca.pem").to_str().unwrap(),
-             test_path.join("client.crt").to_str().unwrap(),
-             test_path.join("client.key").to_str().unwrap(),
-             false)
-        .connect("127.0.0.1", 27018)
+        .connect_with_ssl("mongodb://127.0.0.1:27018",
+                          test_path.join("ca.pem").to_str().unwrap(),
+                          test_path.join("client.crt").to_str().unwrap(),
+                          test_path.join("client.key").to_str().unwrap(),
+                          false)
         .unwrap();
     let db = client.db("test");
     let coll = db.collection("stuff");


### PR DESCRIPTION


This is the first step towards #191. Since ClientOptions seems like the most reasonable choice of what to implement [`ManageConnection`](https://docs.rs/r2d2/0.7.2/r2d2/trait.ManageConnection.html)  on, I've refactored it into a builder for Clients, which now no longer have any `connect` methods on them.

One thing that we've run into in regards to connections pools on the C++ driver is that changing the state of a client (e.g. setting a read preference or write concern) and then returning it to the pool means that the next time a user obtains that client from the pool, it will already have the custom state, which is generally not expected. We came to the conclusion that since setting the read preference or write concern at the client level rather than the database or collection level (or just for a single operation) is generally not a good way of doing things in the first place (as it only exists for legacy reasons anyhow), we would just document that setting the read preference, etc. on a client from a pool is a programming error. Given that this is already making a large number of breaking changes, I figured it would be reasonable to remove those options from being present at the client level, since we'd also run into the same issue once we move to a model where we get clients from a pool.

As always, I ran rustfmt, which came with its own set of changes.