### PR TITLE
Migrate to the latest bson and bitflags crates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ license = "Apache-2.0"
 name = "mongodb"
 readme = "README.md"
 repository = "https://github.com/mongodb-labs/mongo-rust-driver-prototype"
-version = "0.2.9"
+version = "0.3.0"
 
 [dependencies]
-bitflags = "0.8.2"
-bson = "0.7.1"
+bitflags = "0.9.1"
+bson = "0.8.0"
 bufstream = "0.1.3"
 byteorder = "1.0.0"
 chrono = "0.3.1"
@@ -29,7 +29,7 @@ version = "~0"
 
 [dependencies.openssl]
 optional = true
-version = "0.9.12"
+version = "0.9.13"
 
 [dependencies.textnonce]
 default-features = false

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The driver is available on crates.io. To use the MongoDB driver in your code, ad
 
 ```
 [dependencies]
-bson = "0.7.1"
-mongodb = "0.2.9"
+bson = "0.8.0"
+mongodb = "0.3.0"
 ```
 
 Alternately, you can use the MongoDB driver with SSL support. To do this, you must have OpenSSL installed on your system. Then, enable the `ssl` feature for MongoDB in your Cargo.toml:
@@ -31,7 +31,7 @@ Alternately, you can use the MongoDB driver with SSL support. To do this, you mu
 ```
 [dependencies]
 ...
-mongodb = { version = "0.2.9", features = ["ssl"] }
+mongodb = { version = "0.3.0", features = ["ssl"] }
 ```
 
 Then, import the bson and driver libraries within your code.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@
 ))]
 
 #[doc(html_root_url = "https://docs.rs/mongodb")]
-#[macro_use(bitflags)]
+#[macro_use]
 extern crate bitflags;
 #[macro_use(bson, doc)]
 extern crate bson;

--- a/src/wire_protocol/flags.rs
+++ b/src/wire_protocol/flags.rs
@@ -3,38 +3,38 @@ use coll::options::{CursorType, FindOptions};
 
 bitflags! {
     /// Represents the bit vector of options for an OP_REPLY message.
-    pub flags OpReplyFlags: i32 {
-        const CURSOR_NOT_FOUND  = 0b00000001,
-        const QUERY_FAILURE     = 0b00000010,
-        const AWAIT_CAPABLE     = 0b00001000,
+    pub struct OpReplyFlags: i32 {
+        const CURSOR_NOT_FOUND  = 0b00000001;
+        const QUERY_FAILURE     = 0b00000010;
+        const AWAIT_CAPABLE     = 0b00001000;
     }
 }
 
 bitflags! {
     /// Represents the bit vector of options for an OP_UPDATE message.
-    pub flags OpUpdateFlags: i32 {
-        const UPSERT       = 0b00000001,
-        const MULTI_UPDATE = 0b00000010,
+    pub struct OpUpdateFlags: i32 {
+        const UPSERT       = 0b00000001;
+        const MULTI_UPDATE = 0b00000010;
     }
 }
 
 bitflags! {
     /// Represents the bit vector of flags for an OP_INSERT message.
-    pub flags OpInsertFlags: i32 {
-        const CONTINUE_ON_ERROR = 0b00000001,
+    pub struct OpInsertFlags: i32 {
+        const CONTINUE_ON_ERROR = 0b00000001;
     }
 }
 
 bitflags! {
     /// Represents the bit vector of flags for an OP_QUERY message.
-    pub flags OpQueryFlags: i32 {
-        const TAILABLE_CURSOR   = 0b00000010,
-        const SLAVE_OK          = 0b00000100,
-        const OPLOG_RELAY       = 0b00001000,
-        const NO_CURSOR_TIMEOUT = 0b00010000,
-        const AWAIT_DATA        = 0b00100000,
-        const EXHAUST           = 0b01000000,
-        const PARTIAL           = 0b10000000,
+    pub struct OpQueryFlags: i32 {
+        const TAILABLE_CURSOR   = 0b00000010;
+        const SLAVE_OK          = 0b00000100;
+        const OPLOG_RELAY       = 0b00001000;
+        const NO_CURSOR_TIMEOUT = 0b00010000;
+        const AWAIT_DATA        = 0b00100000;
+        const EXHAUST           = 0b01000000;
+        const PARTIAL           = 0b10000000;
     }
 }
 


### PR DESCRIPTION
I wanted to migrate to the latest `bson` and `bitflags` for my project, but `mongodb` crate uses older versions of these crates, so here is PR.

I've bumped up minor version since dependencies have new minor versions as well, but I'm not 100% sure :) Travis is green for my branch.