### PR TITLE
fix race condition causing deadlock when acquiring locks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,9 +92,9 @@
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 #![cfg_attr(feature = "clippy", allow(
     doc_markdown,
-    // allow double_parens for bson/doc macro.
+// allow double_parens for bson/doc macro.
     double_parens,
-    // more explicit than catch-alls.
+// more explicit than catch-alls.
     match_wild_err_arm,
     too_many_arguments,
 ))]
@@ -178,7 +178,7 @@ use error::Error::ResponseError;
 use pool::PooledStream;
 use stream::StreamConnector;
 use topology::{Topology, TopologyDescription, TopologyType, DEFAULT_HEARTBEAT_FREQUENCY_MS,
-DEFAULT_LOCAL_THRESHOLD_MS, DEFAULT_SERVER_SELECTION_TIMEOUT_MS};
+               DEFAULT_LOCAL_THRESHOLD_MS, DEFAULT_SERVER_SELECTION_TIMEOUT_MS};
 use topology::server::Server;
 
 /// Interfaces with a MongoDB server or replica set.
@@ -236,16 +236,17 @@ impl ClientOptions {
 
     #[cfg(feature = "ssl")]
     /// Creates a new options struct with a specified SSL certificate and key files.
-    pub fn with_ssl(ca_file: &str,
-                    certificate_file: &str,
-                    key_file: &str,
-                    verify_peer: bool)
-        -> ClientOptions {
-            let mut options = ClientOptions::new();
-            options.stream_connector = StreamConnector::with_ssl(ca_file, certificate_file,
-                                                                 key_file, verify_peer);
-            options
-        }
+    pub fn with_ssl(
+        ca_file: &str,
+        certificate_file: &str,
+        key_file: &str,
+        verify_peer: bool,
+    ) -> ClientOptions {
+        let mut options = ClientOptions::new();
+        options.stream_connector =
+            StreamConnector::with_ssl(ca_file, certificate_file, key_file, verify_peer);
+        options
+    }
 }
 
 pub trait ThreadedClient: Sync + Sized {
@@ -261,18 +262,20 @@ pub trait ThreadedClient: Sync + Sized {
     fn with_uri_and_options(uri: &str, options: ClientOptions) -> Result<Self>;
     /// Create a new Client with manual connection configurations.
     /// `connect` and `with_uri` should generally be used as higher-level constructors.
-    fn with_config(config: ConnectionString,
-                   options: Option<ClientOptions>,
-                   description: Option<TopologyDescription>)
-        -> Result<Self>;
+    fn with_config(
+        config: ConnectionString,
+        options: Option<ClientOptions>,
+        description: Option<TopologyDescription>,
+    ) -> Result<Self>;
     /// Creates a database representation.
     fn db(&self, db_name: &str) -> Database;
     /// Creates a database representation with custom read and write controls.
-    fn db_with_prefs(&self,
-                     db_name: &str,
-                     read_preference: Option<ReadPreference>,
-                     write_concern: Option<WriteConcern>)
-        -> Database;
+    fn db_with_prefs(
+        &self,
+        db_name: &str,
+        read_preference: Option<ReadPreference>,
+        write_concern: Option<WriteConcern>,
+    ) -> Database;
     /// Acquires a connection stream from the pool, along with slave_ok and should_send_read_pref.
     fn acquire_stream(&self, read_pref: ReadPreference) -> Result<(PooledStream, bool, bool)>;
     /// Acquires a connection stream from the pool for write operations.
@@ -319,75 +322,93 @@ impl ThreadedClient for Client {
         Client::with_config(config, Some(options), None)
     }
 
-    fn with_config(config: ConnectionString,
-                   options: Option<ClientOptions>,
-                   description: Option<TopologyDescription>)
-        -> Result<Client> {
+    fn with_config(
+        config: ConnectionString,
+        options: Option<ClientOptions>,
+        description: Option<TopologyDescription>,
+    ) -> Result<Client> {
 
-            let client_options = options.unwrap_or_else(ClientOptions::new);
+        let client_options = options.unwrap_or_else(ClientOptions::new);
 
-            let rp = client_options.read_preference
-                .unwrap_or_else(|| ReadPreference::new(ReadMode::Primary, None));
-            let wc = client_options.write_concern.unwrap_or_else(WriteConcern::new);
+        let rp = client_options.read_preference.unwrap_or_else(|| {
+            ReadPreference::new(ReadMode::Primary, None)
+        });
+        let wc = client_options.write_concern.unwrap_or_else(
+            WriteConcern::new,
+        );
 
-            let listener = Listener::new();
-            let file = match client_options.log_file {
-                Some(string) => {
-                    let _ = listener.add_start_hook(log_command_started);
-                    let _ = listener.add_completion_hook(log_command_completed);
-                    Some(Mutex::new(try!(OpenOptions::new()
-                                         .write(true)
-                                         .append(true)
-                                         .create(true)
-                                         .open(&string))))
-                }
-                None => None,
-            };
-
-            let client = Arc::new(ClientInner {
-                req_id: Arc::new(ATOMIC_ISIZE_INIT),
-                topology: try!(Topology::new(config.clone(), description, client_options.stream_connector.clone())),
-                listener: listener,
-                read_preference: rp,
-                write_concern: wc,
-                log_file: file,
-            });
-
-            // Fill servers array and set options
-            {
-                let top_description = &client.topology.description;
-                let mut top = try!(top_description.write());
-                top.heartbeat_frequency_ms = client_options.heartbeat_frequency_ms;
-                top.server_selection_timeout_ms = client_options.server_selection_timeout_ms;
-                top.local_threshold_ms = client_options.local_threshold_ms;
-
-                for host in &config.hosts {
-                    let server = Server::new(client.clone(), host.clone(), top_description.clone(), true, client_options.stream_connector.clone());
-
-                    top.servers.insert(host.clone(), server);
-                }
+        let listener = Listener::new();
+        let file = match client_options.log_file {
+            Some(string) => {
+                let _ = listener.add_start_hook(log_command_started);
+                let _ = listener.add_completion_hook(log_command_completed);
+                Some(Mutex::new(try!(
+                    OpenOptions::new()
+                        .write(true)
+                        .append(true)
+                        .create(true)
+                        .open(&string)
+                )))
             }
+            None => None,
+        };
 
-            Ok(client)
+        let client = Arc::new(ClientInner {
+            req_id: Arc::new(ATOMIC_ISIZE_INIT),
+            topology: try!(Topology::new(
+                config.clone(),
+                description,
+                client_options.stream_connector.clone(),
+            )),
+            listener: listener,
+            read_preference: rp,
+            write_concern: wc,
+            log_file: file,
+        });
+
+        // Fill servers array and set options
+        {
+            let top_description = &client.topology.description;
+            let mut top = try!(top_description.write());
+            top.heartbeat_frequency_ms = client_options.heartbeat_frequency_ms;
+            top.server_selection_timeout_ms = client_options.server_selection_timeout_ms;
+            top.local_threshold_ms = client_options.local_threshold_ms;
+
+            for host in &config.hosts {
+                let server = Server::new(
+                    client.clone(),
+                    host.clone(),
+                    top_description.clone(),
+                    true,
+                    client_options.stream_connector.clone(),
+                );
+
+                top.servers.insert(host.clone(), server);
+            }
         }
+
+        Ok(client)
+    }
 
     fn db(&self, db_name: &str) -> Database {
         Database::open(self.clone(), db_name, None, None)
     }
 
-    fn db_with_prefs(&self,
-                     db_name: &str,
-                     read_preference: Option<ReadPreference>,
-                     write_concern: Option<WriteConcern>)
-        -> Database {
-            Database::open(self.clone(), db_name, read_preference, write_concern)
-        }
+    fn db_with_prefs(
+        &self,
+        db_name: &str,
+        read_preference: Option<ReadPreference>,
+        write_concern: Option<WriteConcern>,
+    ) -> Database {
+        Database::open(self.clone(), db_name, read_preference, write_concern)
+    }
 
-    fn acquire_stream(&self,
-                      read_preference: ReadPreference)
-        -> Result<(PooledStream, bool, bool)> {
-            self.topology.acquire_stream(read_preference)
-        }
+    fn acquire_stream(
+        &self,
+        read_preference: ReadPreference,
+    ) -> Result<(PooledStream, bool, bool)> {
+        self.topology.acquire_stream(read_preference)
+    }
 
     fn acquire_write_stream(&self) -> Result<PooledStream> {
         self.topology.acquire_write_stream()
@@ -405,7 +426,8 @@ impl ThreadedClient for Client {
         let res = try!(db.command(doc, CommandType::ListDatabases, None));
         if let Some(&Bson::Array(ref batch)) = res.get("databases") {
             // Extract database names
-            let map = batch.iter()
+            let map = batch
+                .iter()
                 .filter_map(|bdoc| {
                     if let Bson::Document(ref doc) = *bdoc {
                         if let Some(&Bson::String(ref name)) = doc.get("name") {
@@ -414,11 +436,13 @@ impl ThreadedClient for Client {
                     }
                     None
                 })
-            .collect();
+                .collect();
             return Ok(map);
         }
 
-        Err(ResponseError(String::from("Server reply does not contain 'databases'.")))
+        Err(ResponseError(
+            String::from("Server reply does not contain 'databases'."),
+        ))
     }
 
     fn drop_database(&self, db_name: &str) -> Result<()> {
@@ -436,7 +460,9 @@ impl ThreadedClient for Client {
 
         match res.get("ismaster") {
             Some(&Bson::Boolean(is_master)) => Ok(is_master),
-            _ => Err(ResponseError(String::from("Server reply does not contain 'ismaster'."))),
+            _ => Err(ResponseError(
+                String::from("Server reply does not contain 'ismaster'."),
+            )),
         }
     }
 

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -80,12 +80,12 @@ impl FromStr for TopologyType {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self> {
         Ok(match s {
-               "Single" => TopologyType::Single,
-               "ReplicaSetNoPrimary" => TopologyType::ReplicaSetNoPrimary,
-               "ReplicaSetWithPrimary" => TopologyType::ReplicaSetWithPrimary,
-               "Sharded" => TopologyType::Sharded,
-               _ => TopologyType::Unknown,
-           })
+            "Single" => TopologyType::Single,
+            "ReplicaSetNoPrimary" => TopologyType::ReplicaSetNoPrimary,
+            "ReplicaSetWithPrimary" => TopologyType::ReplicaSetWithPrimary,
+            "Sharded" => TopologyType::Sharded,
+            _ => TopologyType::Unknown,
+        })
     }
 }
 
@@ -146,7 +146,9 @@ impl TopologyDescription {
                 }
             }
         }
-        Err(OperationError(String::from("No servers available for the provided ReadPreference.")))
+        Err(OperationError(String::from(
+            "No servers available for the provided ReadPreference.",
+        )))
     }
 
     /// Returns a random server stream from the vector.
@@ -164,18 +166,22 @@ impl TopologyDescription {
             }
             servers.remove(index);
         }
-        Err(OperationError(String::from("No servers available for the provided ReadPreference.")))
+        Err(OperationError(String::from(
+            "No servers available for the provided ReadPreference.",
+        )))
     }
 
     /// Returns a server stream for read operations.
-    pub fn acquire_stream(&self,
-                          read_preference: &ReadPreference)
-                          -> Result<(PooledStream, bool, bool)> {
+    pub fn acquire_stream(
+        &self,
+        read_preference: &ReadPreference,
+    ) -> Result<(PooledStream, bool, bool)> {
         let (mut hosts, rand) = self.choose_hosts(read_preference)?;
 
         // Filter hosts by tagsets
         if self.topology_type != TopologyType::Sharded &&
-           self.topology_type != TopologyType::Single {
+            self.topology_type != TopologyType::Single
+        {
             self.filter_hosts(&mut hosts, read_preference);
         }
 
@@ -312,15 +318,16 @@ impl TopologyDescription {
                 // If no tags match but the replica set has a primary that is returnable with
                 // the given ReadMode, return that primary server.
                 if self.topology_type == TopologyType::ReplicaSetWithPrimary &&
-                   (read_preference.mode == ReadMode::Primary ||
-                    read_preference.mode == ReadMode::PrimaryPreferred) {
+                    (read_preference.mode == ReadMode::Primary ||
+                         read_preference.mode == ReadMode::PrimaryPreferred)
+                {
                     // Retain primaries.
                     hosts.retain(|host| if let Some(server) = self.servers.get(host) {
-                                     let description = server.description.read().unwrap();
-                                     description.server_type == ServerType::RSPrimary
-                                 } else {
-                                     false
-                                 });
+                        let description = server.description.read().unwrap();
+                        description.server_type == ServerType::RSPrimary
+                    } else {
+                        false
+                    });
                 } else {
                     // If no tags match and the above case does not occur,
                     // filter out all provided servers.
@@ -361,21 +368,20 @@ impl TopologyDescription {
         }
 
         // Find the shortest round-trip time.
-        let shortest_rtt = hosts
-            .iter()
-            .fold({
-                      // Initialize the value to the first server's round-trip-time, or i64::MAX.
-                      if let Some(server) = self.servers.get(&hosts[0]) {
-                          if let Ok(description) = server.description.read() {
-                              description.round_trip_time.unwrap_or(i64::MAX)
-                          } else {
-                              i64::MAX
-                          }
-                      } else {
-                          i64::MAX
-                      }
-                  },
-                  |acc, host| {
+        let shortest_rtt = hosts.iter().fold(
+            {
+                // Initialize the value to the first server's round-trip-time, or i64::MAX.
+                if let Some(server) = self.servers.get(&hosts[0]) {
+                    if let Ok(description) = server.description.read() {
+                        description.round_trip_time.unwrap_or(i64::MAX)
+                    } else {
+                        i64::MAX
+                    }
+                } else {
+                    i64::MAX
+                }
+            },
+            |acc, host| {
                 // Compare the previous shortest rtt with the host rtt.
                 if let Some(server) = self.servers.get(host) {
                     if let Ok(description) = server.description.read() {
@@ -388,7 +394,8 @@ impl TopologyDescription {
                     }
                 }
                 acc
-            });
+            },
+        );
 
         // If the shortest rtt is i64::MAX, all server rtts are None or could not be read.
         if shortest_rtt == i64::MAX {
@@ -423,20 +430,22 @@ impl TopologyDescription {
             TopologyType::Sharded => (self.servers.keys().cloned().collect(), false),
             // Only primary replica set members are suitable.
             _ => {
-                (self.servers
-                     .keys()
-                     .filter_map(|host| {
-                    if let Some(server) = self.servers.get(host) {
-                        if let Ok(description) = server.description.read() {
-                            if description.server_type == ServerType::RSPrimary {
-                                return Some(host.clone());
+                (
+                    self.servers
+                        .keys()
+                        .filter_map(|host| {
+                            if let Some(server) = self.servers.get(host) {
+                                if let Ok(description) = server.description.read() {
+                                    if description.server_type == ServerType::RSPrimary {
+                                        return Some(host.clone());
+                                    }
+                                }
                             }
-                        }
-                    }
-                    None
-                })
-                     .collect(),
-                 true)
+                            None
+                        })
+                        .collect(),
+                    true,
+                )
             }
         }
     }
@@ -511,32 +520,38 @@ impl TopologyDescription {
     }
 
     /// Update the topology description, but don't start any monitors for new servers.
-    pub fn update_without_monitor(&mut self,
-                                  host: Host,
-                                  description: ServerDescription,
-                                  client: Client,
-                                  top_arc: Arc<RwLock<TopologyDescription>>) {
+    pub fn update_without_monitor(
+        &mut self,
+        host: Host,
+        description: Arc<RwLock<ServerDescription>>,
+        client: Client,
+        top_arc: Arc<RwLock<TopologyDescription>>,
+    ) {
         self.update_private(host, description, client, top_arc, false);
     }
 
     /// Updates the topology description based on an updated server description.
-    pub fn update(&mut self,
-                  host: Host,
-                  description: ServerDescription,
-                  client: Client,
-                  top_arc: Arc<RwLock<TopologyDescription>>) {
+    pub fn update(
+        &mut self,
+        host: Host,
+        description: Arc<RwLock<ServerDescription>>,
+        client: Client,
+        top_arc: Arc<RwLock<TopologyDescription>>,
+    ) {
         self.update_private(host, description, client, top_arc, true);
     }
 
     // Internal topology description update helper.
-    fn update_private(&mut self,
-                      host: Host,
-                      description: ServerDescription,
-                      client: Client,
-                      top_arc: Arc<RwLock<TopologyDescription>>,
-                      run_monitor: bool) {
+    fn update_private(
+        &mut self,
+        host: Host,
+        description: Arc<RwLock<ServerDescription>>,
+        client: Client,
+        top_arc: Arc<RwLock<TopologyDescription>>,
+        run_monitor: bool,
+    ) {
 
-        let stype = description.server_type;
+        let stype = description.read().unwrap().server_type;
         match self.topology_type {
             TopologyType::Unknown => {
                 match stype {
@@ -546,11 +561,13 @@ impl TopologyDescription {
                         self.update_rs_from_primary(host, description, client, top_arc, run_monitor)
                     }
                     ServerType::RSSecondary | ServerType::RSArbiter | ServerType::RSOther => {
-                        self.update_rs_without_primary(host,
-                                                       description,
-                                                       client,
-                                                       top_arc,
-                                                       run_monitor)
+                        self.update_rs_without_primary(
+                            host,
+                            description,
+                            client,
+                            top_arc,
+                            run_monitor,
+                        )
                     }
                     _ => (),
                 }
@@ -565,11 +582,13 @@ impl TopologyDescription {
                         self.update_rs_from_primary(host, description, client, top_arc, run_monitor)
                     }
                     ServerType::RSSecondary | ServerType::RSArbiter | ServerType::RSOther => {
-                        self.update_rs_without_primary(host,
-                                                       description,
-                                                       client,
-                                                       top_arc,
-                                                       run_monitor)
+                        self.update_rs_without_primary(
+                            host,
+                            description,
+                            client,
+                            top_arc,
+                            run_monitor,
+                        )
                     }
                     _ => self.check_if_has_primary(),
                 }
@@ -628,20 +647,24 @@ impl TopologyDescription {
     }
 
     // Updates a replica set topology with a new primary server description.
-    fn update_rs_from_primary(&mut self,
-                              host: Host,
-                              description: ServerDescription,
-                              client: Client,
-                              top_arc: Arc<RwLock<TopologyDescription>>,
-                              run_monitor: bool) {
+    fn update_rs_from_primary(
+        &mut self,
+        host: Host,
+        description: Arc<RwLock<ServerDescription>>,
+        client: Client,
+        top_arc: Arc<RwLock<TopologyDescription>>,
+        run_monitor: bool,
+    ) {
 
         if !self.servers.contains_key(&host) {
             return;
         }
 
+        let description_set_name = description.read().unwrap().set_name.clone();
+
         if self.set_name.is_empty() {
-            self.set_name = description.set_name.to_owned();
-        } else if self.set_name != description.set_name {
+            self.set_name = description_set_name;
+        } else if self.set_name != description_set_name {
             // Primary found, but it doesn't have the setName
             // provided by the user or previously discovered.
             self.servers.remove(&host);
@@ -649,12 +672,22 @@ impl TopologyDescription {
             return;
         }
 
-        if description.set_version.is_some() && description.election_id.is_some() {
+        let (description_set_version, description_election_id) = {
+            let description_guard = description.read().unwrap();
+
+            (
+                description_guard.set_version,
+                description_guard.election_id.clone(),
+            )
+        };
+
+        if description_set_version.is_some() && description_election_id.is_some() {
             if self.max_set_version.is_some() && self.max_election_id.is_some() &&
-               (self.max_set_version.unwrap() > description.set_version.unwrap() ||
-                (self.max_set_version.unwrap() == description.set_version.unwrap() &&
-                 self.max_election_id.as_ref().unwrap() >
-                 description.election_id.as_ref().unwrap())) {
+                (self.max_set_version.unwrap() > description_set_version.unwrap() ||
+                     (self.max_set_version.unwrap() == description_set_version.unwrap() &&
+                          self.max_election_id.as_ref().unwrap() >
+                              description_election_id.as_ref().unwrap()))
+            {
                 // Stale primary
                 if let Some(server) = self.servers.get(&host) {
                     {
@@ -667,14 +700,15 @@ impl TopologyDescription {
                 self.check_if_has_primary();
                 return;
             } else {
-                self.max_election_id = description.election_id.clone();
+                self.max_election_id = description_election_id.clone();
             }
         }
 
-        if description.set_version.is_some() &&
-           (self.max_set_version.is_none() ||
-            description.set_version.unwrap() > self.max_set_version.unwrap()) {
-            self.max_set_version = description.set_version;
+        if description_set_version.is_some() &&
+            (self.max_set_version.is_none() ||
+                 description_set_version.unwrap() > self.max_set_version.unwrap())
+        {
+            self.max_set_version = description_set_version;
         }
 
         // Invalidate any old primaries
@@ -689,48 +723,56 @@ impl TopologyDescription {
             }
         }
 
-        self.add_missing_hosts(&description, client, top_arc, run_monitor);
+        self.add_missing_hosts(description.clone(), client, top_arc, run_monitor);
 
         // Remove hosts that are not reported by the primary.
-        let mut hosts_to_remove = Vec::new();
-        for host in self.servers.keys() {
-            if !description.hosts.contains(host) && !description.passives.contains(host) &&
-               !description.arbiters.contains(host) {
-                hosts_to_remove.push(host.clone());
-            }
-        }
+        let valid_hosts: Vec<_> = {
+            let description_guard = description.read().unwrap();
 
-        for host in hosts_to_remove {
-            self.servers.remove(&host);
-        }
+            description_guard
+                .hosts
+                .iter()
+                .cloned()
+                .chain(description_guard.passives.iter().cloned())
+                .chain(description_guard.arbiters.iter().cloned())
+                .collect()
+        };
+
+        self.servers.retain(|host, _| valid_hosts.contains(host));
 
         self.check_if_has_primary();
     }
 
     // Updates a replica set topology with a missing primary.
-    fn update_rs_without_primary(&mut self,
-                                 host: Host,
-                                 description: ServerDescription,
-                                 client: Client,
-                                 top_arc: Arc<RwLock<TopologyDescription>>,
-                                 run_monitor: bool) {
+    fn update_rs_without_primary(
+        &mut self,
+        host: Host,
+        description: Arc<RwLock<ServerDescription>>,
+        client: Client,
+        top_arc: Arc<RwLock<TopologyDescription>>,
+        run_monitor: bool,
+    ) {
 
         self.topology_type = TopologyType::ReplicaSetNoPrimary;
         if !self.servers.contains_key(&host) {
             return;
         }
 
+        let set_name = description.read().unwrap().set_name.clone();
+
         if self.set_name.is_empty() {
-            self.set_name = description.set_name.to_owned();
-        } else if self.set_name != description.set_name {
+            self.set_name = set_name;
+        } else if self.set_name != set_name {
             self.servers.remove(&host);
             self.check_if_has_primary();
             return;
         }
 
-        self.add_missing_hosts(&description, client, top_arc, run_monitor);
+        self.add_missing_hosts(description.clone(), client, top_arc, run_monitor);
 
-        if let Some(me) = description.me {
+        let description_me = description.read().unwrap().me.clone();
+
+        if let Some(me) = description_me {
             if host != me {
                 self.servers.remove(&host);
                 self.check_if_has_primary();
@@ -739,16 +781,22 @@ impl TopologyDescription {
     }
 
     // Updates a replica set topology with an updated member description.
-    fn update_rs_with_primary_from_member(&mut self, host: Host, description: ServerDescription) {
+    fn update_rs_with_primary_from_member(
+        &mut self,
+        host: Host,
+        description: Arc<RwLock<ServerDescription>>,
+    ) {
         if !self.servers.contains_key(&host) {
             return;
         }
 
-        if self.set_name != description.set_name {
+        if self.set_name != description.read().unwrap().set_name {
             self.servers.remove(&host);
         }
 
-        if let Some(me) = description.me {
+        let description_me = description.read().unwrap().me.clone();
+
+        if let Some(me) = description_me {
             if host != me {
                 self.servers.remove(&host);
             }
@@ -759,42 +807,36 @@ impl TopologyDescription {
     }
 
     // Begins monitoring hosts that are not currently being monitored.
-    fn add_missing_hosts(&mut self,
-                         description: &ServerDescription,
-                         client: Client,
-                         top_arc: Arc<RwLock<TopologyDescription>>,
-                         run_monitor: bool) {
+    fn add_missing_hosts(
+        &mut self,
+        description: Arc<RwLock<ServerDescription>>,
+        client: Client,
+        top_arc: Arc<RwLock<TopologyDescription>>,
+        run_monitor: bool,
+    ) {
 
-        for host in &description.hosts {
-            if !self.servers.contains_key(host) {
-                let server = Server::new(client.clone(),
-                                         host.clone(),
-                                         top_arc.clone(),
-                                         run_monitor,
-                                         self.stream_connector.clone());
-                self.servers.insert(host.clone(), server);
-            }
-        }
+        let hosts: Vec<_> = {
+            let description_guard = description.read().unwrap();
 
-        for host in &description.passives {
-            if !self.servers.contains_key(host) {
-                let server = Server::new(client.clone(),
-                                         host.clone(),
-                                         top_arc.clone(),
-                                         run_monitor,
-                                         self.stream_connector.clone());
-                self.servers.insert(host.clone(), server);
-            }
-        }
+            description_guard
+                .hosts
+                .iter()
+                .cloned()
+                .chain(description_guard.passives.iter().cloned())
+                .chain(description_guard.arbiters.iter().cloned())
+                .collect()
+        };
 
-        for host in &description.arbiters {
-            if !self.servers.contains_key(host) {
-                let server = Server::new(client.clone(),
-                                         host.clone(),
-                                         top_arc.clone(),
-                                         run_monitor,
-                                         self.stream_connector.clone());
-                self.servers.insert(host.clone(), server);
+        for host in hosts {
+            if !self.servers.contains_key(&host) {
+                let server = Server::new(
+                    client.clone(),
+                    host.clone(),
+                    top_arc.clone(),
+                    run_monitor,
+                    self.stream_connector.clone(),
+                );
+                self.servers.insert(host, server);
             }
         }
     }
@@ -802,16 +844,19 @@ impl TopologyDescription {
 
 impl Topology {
     /// Returns a new topology with the given configuration and description.
-    pub fn new(config: ConnectionString,
-               description: Option<TopologyDescription>,
-               connector: StreamConnector)
-               -> Result<Topology> {
+    pub fn new(
+        config: ConnectionString,
+        description: Option<TopologyDescription>,
+        connector: StreamConnector,
+    ) -> Result<Topology> {
 
         let mut options = description.unwrap_or_else(|| TopologyDescription::new(connector));
 
         if config.hosts.len() > 1 && options.topology_type == TopologyType::Single {
-            return Err(ArgumentError(String::from("TopologyType::Single cannot be used with \
-                                                   multiple seeds.")));
+            return Err(ArgumentError(String::from(
+                "TopologyType::Single cannot be used with \
+                                                   multiple seeds.",
+            )));
         }
 
         if let Some(ref config_opts) = config.options {
@@ -822,62 +867,67 @@ impl Topology {
         }
 
         if !options.set_name.is_empty() &&
-           options.topology_type != TopologyType::ReplicaSetNoPrimary {
-            return Err(ArgumentError(String::from("TopologyType must be ReplicaSetNoPrimary if \
-                                                   set_name is provided.")));
+            options.topology_type != TopologyType::ReplicaSetNoPrimary
+        {
+            return Err(ArgumentError(String::from(
+                "TopologyType must be ReplicaSetNoPrimary if \
+                                                   set_name is provided.",
+            )));
         }
 
         let top_description = Arc::new(RwLock::new(options));
 
         Ok(Topology {
-               config: config,
-               description: top_description,
-           })
+            config: config,
+            description: top_description,
+        })
     }
 
     // Private server stream acquisition helper.
-    fn acquire_stream_private(&self,
-                              read_preference: Option<ReadPreference>,
-                              write: bool)
-                              -> Result<(PooledStream, bool, bool)> {
+    fn acquire_stream_private(
+        &self,
+        read_preference: Option<ReadPreference>,
+        write: bool,
+    ) -> Result<(PooledStream, bool, bool)> {
         // Note start of server selection.
         let time = time::get_time();
         let start_ms = time.sec * 1000 + (time.nsec as i64) / 1000000;
 
         loop {
-            {
-                let description = try!(self.description.read());
-                let result = if write {
-                    match description.acquire_write_stream() {
-                        Ok(stream) => Ok((stream, false, false)),
-                        Err(err) => Err(err),
-                    }
-                } else {
-                    description.acquire_stream(read_preference.as_ref().unwrap())
-                };
+            let result = if write {
+                match self.description.read()?.acquire_write_stream() {
+                    Ok(stream) => Ok((stream, false, false)),
+                    Err(err) => Err(err),
+                }
+            } else {
+                self.description.read()?.acquire_stream(
+                    read_preference.as_ref().unwrap(),
+                )
+            };
 
-                match result {
-                    Ok(stream) => return Ok(stream),
-                    Err(err) => {
-                        // Check duration of current server selection and return an error if
-                        // overdue.
-                        let end_time = time::get_time();
-                        let end_ms = end_time.sec * 1000 + (end_time.nsec as i64) / 1000000;
-                        if end_ms - start_ms >= description.server_selection_timeout_ms {
-                            return Err(err);
-                        }
+            match result {
+                Ok(stream) => return Ok(stream),
+                Err(err) => {
+                    // Check duration of current server selection and return an error if
+                    // overdue.
+                    let end_time = time::get_time();
+                    let end_ms = end_time.sec * 1000 + (end_time.nsec as i64) / 1000000;
+                    if end_ms - start_ms >= self.description.read()?.server_selection_timeout_ms {
+                        return Err(err);
                     }
                 }
-            }
+            };
+
             // Otherwise, sleep for a little while.
             thread::sleep(Duration::from_millis(500));
         }
     }
 
     /// Returns a server stream for read operations.
-    pub fn acquire_stream(&self,
-                          read_preference: ReadPreference)
-                          -> Result<(PooledStream, bool, bool)> {
+    pub fn acquire_stream(
+        &self,
+        read_preference: ReadPreference,
+    ) -> Result<(PooledStream, bool, bool)> {
         self.acquire_stream_private(Some(read_preference), false)
     }
 

--- a/tests/sdam/framework.rs
+++ b/tests/sdam/framework.rs
@@ -80,13 +80,10 @@ pub fn run_suite(file: &str, description: Option<TopologyDescription>) {
                 }
             }
 
-            let server_description = {
-                let server = servers.get(&host).expect("Host not found.");
-                server.description.read().unwrap().clone()
-            };
+            let server = servers.get(&host).expect("Host not found.");
 
             topology_description.update_without_monitor(host.clone(),
-                                                        server_description.clone(),
+                                                        server.description.clone(),
                                                         dummy_client.clone(),
                                                         top_description_arc.clone());
         }


### PR DESCRIPTION
This fixes #216. From my description of the bug in the issue:

"We have a few types dealing with the state of the topology wrapped up in RwLocks that are shared between all the monitoring threads and all the connection threads. When the monitoring threads check to make sure that we didn't lose connection to any of the servers, they acquire locks on those data structures to be able to inspect their state. Before the fix, we were passing the lock guards through to the functions that handled the case of a topology update (due to things like a lost connection to a server or a new primary being elected). When updating the topology, one of the things the driver does is check each server for stale information and update it in the case that it does; however, updating this information requires acquiring a lock on the data structure that contains the stale information. From what I can tell, the race condition occurs when the monitoring thread that detects the need for a topology update happens to be monitoring a server that the driver has stale information for, which then causes the driver to try to acquire a write lock on the same data structure whose lock guard is already being passed around, which causes deadlock. RwLock tries to detect when deadlock might occur and will panic if it does so, which is what caused the PoisonLock error that you were getting. Having the driver pass around the RwLock itself instead of the acquired guard on it (and then only acquiring the lock when it's needed in the topology update and making sure to release it once it's no longer needed) ensures that there won't be any attempt to acquire a lock that's already been acquired, which removes the deadlock."

tl;dr We were passing a lock guard through the topology update functions rather than the `RwLock`'d struct itself, and sometimes we'd try to acquire a write lock on the same thing, which is obviously Very Bad (tm).