### PR TITLE
Allowed IndexModel keys to map to text, hashed, 2d and 2dsphere

### DIFF
--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -365,7 +365,11 @@ impl IndexModel {
             name.push('_');
             match *bson {
                 Bson::I32(ref i) => name.push_str(&format!("{}", i)),
-                _ => return Err(ArgumentError(String::from("Index model keys must map to i32."))),
+                Bson::String(ref s) if s == "text" || s == "hashed" || s == "2d" || s == "2dsphere"
+                    => name.push_str(s),
+                _ => return Err(ArgumentError(String::from(
+                            "Index model keys must map to i32, \"text\", \"hashed\", \"2d\" or \"2dsphere\""
+                            ))),
             }
         }
         Ok(name)


### PR DESCRIPTION
Currently, text indexes cannot be created with this driver. This issues has been described in #223.

This PR does nothing more than adding a match arm to accept values other than i32 in the IndexModel.