### PR TITLE
[#235] Add `with_unauthenticated_ssl` for unauthenticated ssl encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ fn main() {
 }
 ```
 
-To connect with SSL, use `ClientOptions::with_ssl`, `ClientOptions::with_unauthenticated_ssl`, and `Client::connect_with_options`. Afterwards, the client can be used as above (note that the server will have to be configured to accept SSL connections and that you'll have to generate your own keys and certificates):
+To connect with SSL, use `ClientOptions::with_ssl` or `ClientOptions::with_unauthenticated_ssl`, and `Client::connect_with_options`. Afterwards, the client can be used as above (note that the server will have to be configured to accept SSL connections and that you'll have to generate your own keys and certificates):
 
 ```rust
 use bson::Bson;

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ fn main() {
 }
 ```
 
-To connect with SSL, use `ClientOptions::with_ssl` or `ClientOptions::with_unauthenticated_ssl`, and `Client::connect_with_options`. Afterwards, the client can be used as above (note that the server will have to be configured to accept SSL connections and that you'll have to generate your own keys and certificates):
+To connect with SSL, use either `ClientOptions::with_ssl` or `ClientOptions::with_unauthenticated_ssl` and then `Client::connect_with_options`. Afterwards, the client can be used as above (note that the server will have to be configured to accept SSL connections and that you'll have to generate your own keys and certificates):
 
 ```rust
 use bson::Bson;

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ fn main() {
 }
 ```
 
-To connect with SSL, use `ClientOptions::with_ssl` and `Client::connect_with_options`. Afterwards, the client can be used as above (note that the server will have to be configured to accept SSL connections and that you'll have to generate your own keys and certificates):
+To connect with SSL, use `ClientOptions::with_ssl`, `ClientOptions::with_unauthenticated_ssl`, and `Client::connect_with_options`. Afterwards, the client can be used as above (note that the server will have to be configured to accept SSL connections and that you'll have to generate your own keys and certificates):
 
 ```rust
 use bson::Bson;

--- a/script/start_mongo_release
+++ b/script/start_mongo_release
@@ -21,4 +21,4 @@ data_ssl="$data-ssl"
 
 mkdir -p $data $data_ssl
 $install_dir/$release/bin/mongod --fork --dbpath $data --syslog --port 27017
-$install_dir/$release/bin/mongod --fork --dbpath $data_ssl --syslog --port 27018 --sslMode requireSSL --sslPEMKeyFile tests/ssl/server.pem --sslCAFile tests/ssl/ca.pem
+$install_dir/$release/bin/mongod --fork --dbpath $data_ssl --syslog --port 27018 --sslMode requireSSL --sslPEMKeyFile tests/ssl/server.pem --sslCAFile tests/ssl/ca.pem --sslAllowConnectionsWithoutCertificates

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,6 +247,18 @@ impl ClientOptions {
             StreamConnector::with_ssl(ca_file, certificate_file, key_file, verify_peer);
         options
     }
+
+    #[cfg(feature = "ssl")]
+    /// Creates a new options struct with a specified SSL certificate
+    pub fn with_unauthenticated_ssl(
+        ca_file: &str,
+        verify_peer: bool,
+    ) -> ClientOptions {
+        let mut options = ClientOptions::new();
+        options.stream_connector =
+           StreamConnector::with_unauthenticated_ssl(ca_file, verify_peer);
+        options
+    }
 }
 
 pub trait ThreadedClient: Sync + Sized {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -17,8 +17,7 @@ pub enum StreamConnector {
     #[cfg(feature = "ssl")]
     /// Connect to the server through a TCP stream encrypted with SSL.
     ///
-    /// If a client certificate file shall be used, a client key file must be set as well. Only if
-    /// both files are set, a client authenticated connection may be established.
+    /// Note that it's invalid to have one of certificate_file and key_file set but not the other.
     Ssl {
         ca_file: String,
         certificate_file: Option<String>,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -16,6 +16,9 @@ pub enum StreamConnector {
     Tcp,
     #[cfg(feature = "ssl")]
     /// Connect to the server through a TCP stream encrypted with SSL.
+    ///
+    /// If a client certificate file shall be used, a client key file must be set as well. Only if
+    /// both files are set, a client authenticated connection may be established.
     Ssl {
         ca_file: String,
         certificate_file: Option<String>,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -18,8 +18,8 @@ pub enum StreamConnector {
     /// Connect to the server through a TCP stream encrypted with SSL.
     Ssl {
         ca_file: String,
-        certificate_file: String,
-        key_file: String,
+        certificate_file: Option<String>,
+        key_file: Option<String>,
         verify_peer: bool,
     },
 }
@@ -57,8 +57,36 @@ impl StreamConnector {
                     -> Self {
         StreamConnector::Ssl {
             ca_file: String::from(ca_file),
-            certificate_file: String::from(certificate_file),
-            key_file: String::from(key_file),
+            certificate_file: Some(String::from(certificate_file)),
+            key_file: Some(String::from(key_file)),
+            verify_peer: verify_peer,
+        }
+    }
+
+    #[cfg(feature = "ssl")]
+    /// Creates an unauthenticated StreamConnector that will connect with SSL encryption.
+    ///
+    /// The SSL connection will use the cipher with the longest key length available to both the
+    /// server and client, with the following caveats:
+    ///   * SSLv2 and SSlv3 are disabled
+    ///   * Export-strength ciphers are disabled
+    ///   * Ciphers not offering encryption are disabled
+    ///   * Ciphers not offering authentication are disabled
+    ///   * Ciphers with key lengths of 128 or fewer bits are disabled.
+    ///
+    /// Note that TLS compression is disabled for SSL connections.
+    ///
+    /// # Arguments
+    ///
+    /// `ca_file` - Path to the file containing trusted CA certificates.
+    /// `verify_peer` - Whether or not to verify that the server's certificate is trusted.
+    pub fn with_unauthenticated_ssl(ca_file: &str,
+                    verify_peer: bool)
+                    -> Self {
+        StreamConnector::Ssl {
+            ca_file: String::from(ca_file),
+            certificate_file: None,
+            key_file: None,
             verify_peer: verify_peer,
         }
     }
@@ -79,8 +107,12 @@ impl StreamConnector {
                 ssl_context.set_options(SSL_OP_NO_SSLV3);
                 ssl_context.set_options(SSL_OP_NO_COMPRESSION);
                 ssl_context.set_ca_file(ca_file)?;
-                ssl_context.set_certificate_file(certificate_file, X509_FILETYPE_PEM)?;
-                ssl_context.set_private_key_file(key_file, X509_FILETYPE_PEM)?;
+                if let &Some(ref file) = certificate_file {
+                    ssl_context.set_certificate_file(file, X509_FILETYPE_PEM)?;
+                }
+                if let &Some(ref file) = key_file {
+                    ssl_context.set_private_key_file(file, X509_FILETYPE_PEM)?;
+                }
 
                 let verify = if verify_peer {
                     SSL_VERIFY_PEER

--- a/tests/ssl/mod.rs
+++ b/tests/ssl/mod.rs
@@ -21,3 +21,20 @@ fn ssl_connect_and_insert() {
 
     coll.insert_one(doc, None).unwrap();
 }
+
+#[test]
+fn unauthenticated_ssl_connect_and_insert() {
+    let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    test_path.push("tests");
+    test_path.push("ssl");
+
+    let options = ClientOptions::with_unauthenticated_ssl(test_path.join("ca.pem").to_str().unwrap(),
+                                          false);
+    let client = Client::connect_with_options("127.0.0.1", 27018, options).unwrap();
+    let db = client.db("test");
+    let coll = db.collection("stuff");
+
+    let doc = doc! { "x" => 1 };
+
+    coll.insert_one(doc, None).unwrap();
+}


### PR DESCRIPTION
This commit allows to create an SSL encrypted connection without requiring to use client authentication -- cf. #235. 