### PR TITLE
Handshake spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ env:
     # Use a global cache to re-use dependencies across release builds; downloading a mongodb release is quick.
     - CACHE_NAME=global_cache
   matrix:
-    - MONGODB_RELEASE=mongodb-linux-x86_64-ubuntu1204-3.0.14
-    - MONGODB_RELEASE=mongodb-linux-x86_64-ubuntu1204-3.2.12
-    - MONGODB_RELEASE=mongodb-linux-x86_64-ubuntu1204-3.4.2
+    - MONGODB_RELEASE=mongodb-linux-x86_64-ubuntu1404-3.0.15
+    - MONGODB_RELEASE=mongodb-linux-x86_64-ubuntu1404-3.2.20
+    - MONGODB_RELEASE=mongodb-linux-x86_64-ubuntu1404-3.4.15
+    - MONGODB_RELEASE=mongodb-linux-x86_64-ubuntu1404-3.6.5
+    - MONGODB_RELEASE=mongodb-linux-x86_64-ubuntu1404-4.0.0
 
 before_install:
     - ./script/start_mongo_release $TRAVIS_OS_NAME $MONGODB_RELEASE

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ version = "0.6.3"
 
 [dev-dependencies]
 approx = "0.1.1"
+serde = "1.0.69"
+serde_derive = "1.0.69"
 
 [dev-dependencies.serde_json]
 features = ["preserve_order"]

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -225,7 +225,7 @@ impl Cursor {
     ) -> Result<Cursor> {
 
         // Select a server stream from the topology.
-        let (stream, slave_ok, send_read_pref) = if cmd_type.is_write_command() {
+        let (mut stream, slave_ok, send_read_pref) = if cmd_type.is_write_command() {
             (try!(client.acquire_write_stream()), false, false)
         } else {
             try!(client.acquire_stream(read_pref.to_owned()))
@@ -254,7 +254,7 @@ impl Cursor {
         };
 
         Cursor::query_with_stream(
-            stream,
+            &mut stream,
             client,
             namespace,
             new_flags,
@@ -267,7 +267,7 @@ impl Cursor {
     }
 
     pub fn query_with_stream(
-        stream: PooledStream,
+        stream: &mut PooledStream,
         client: Client,
         namespace: String,
         flags: OpQueryFlags,
@@ -278,7 +278,6 @@ impl Cursor {
         read_pref: Option<ReadPreference>,
     ) -> Result<Cursor> {
 
-        let mut stream = stream;
         let socket = stream.get_socket();
         let req_id = client.get_req_id();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,8 @@ use topology::{Topology, TopologyDescription, TopologyType, DEFAULT_HEARTBEAT_FR
                DEFAULT_LOCAL_THRESHOLD_MS, DEFAULT_SERVER_SELECTION_TIMEOUT_MS};
 use topology::server::Server;
 
+pub const DRIVER_NAME: &'static str = "mongo-rust-driver-prototype";
+
 /// Interfaces with a MongoDB server or replica set.
 pub struct ClientInner {
     /// Indicates how a server should be selected for read operations.
@@ -415,11 +417,11 @@ impl ThreadedClient for Client {
         &self,
         read_preference: ReadPreference,
     ) -> Result<(PooledStream, bool, bool)> {
-        self.topology.acquire_stream(read_preference)
+        self.topology.acquire_stream(self.clone(), read_preference)
     }
 
     fn acquire_write_stream(&self) -> Result<PooledStream> {
-        self.topology.acquire_write_stream()
+        self.topology.acquire_write_stream(self.clone())
     }
 
     fn get_req_id(&self) -> i32 {

--- a/src/topology/monitor.rs
+++ b/src/topology/monitor.rs
@@ -258,17 +258,16 @@ impl Monitor {
         options.limit = Some(1);
         options.batch_size = Some(1);
 
-
         let flags = OpQueryFlags::with_find_options(&options);
         let mut filter = bson::Document::new();
         filter.insert("isMaster", Bson::I32(1));
 
-        let stream = try!(self.personal_pool.acquire_stream());
+        let mut stream = try!(self.personal_pool.acquire_stream(self.client.clone()));
 
         let time_start = time::get_time();
 
         let cursor = try!(Cursor::query_with_stream(
-            stream,
+            &mut stream,
             self.client.clone(),
             String::from("local.$cmd"),
             flags,

--- a/src/topology/server.rs
+++ b/src/topology/server.rs
@@ -247,8 +247,8 @@ impl Server {
     }
 
     /// Returns a server stream from the connection pool.
-    pub fn acquire_stream(&self) -> Result<PooledStream> {
-        self.pool.acquire_stream()
+    pub fn acquire_stream(&self, client: Client) -> Result<PooledStream> {
+        self.pool.acquire_stream(client)
     }
 
     /// Request an update from the monitor on the server status.

--- a/tests/client/handshake.rs
+++ b/tests/client/handshake.rs
@@ -1,0 +1,46 @@
+use bson::{self, Bson};
+use mongodb::{DRIVER_NAME, Client, ThreadedClient};
+use mongodb::db::ThreadedDatabase;
+use mongodb::CommandType;
+
+#[derive(Debug, Deserialize)]
+struct Metadata {
+    #[serde(rename = "clientMetadata")]
+    pub client: ClientMetadata,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClientMetadata {
+    pub driver: DriverMetadata,
+    pub os: OsMetadata,
+}
+
+#[derive(Debug, Deserialize)]
+struct DriverMetadata {
+    pub name: String,
+    pub version: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OsMetadata {
+    #[serde(rename = "type")]
+    pub os_type: String,
+    pub architecture: String,
+}
+
+#[test]
+fn metadata_sent_in_handshake() {
+    let client = Client::connect("localhost", 27017).unwrap();
+    let db = client.db("admin");
+    skip_if_db_version_below!(db, 3, 4);
+
+    let result = db.command(doc! { "currentOp" => 1 }, CommandType::Suppressed, None).unwrap();
+    let in_prog = match result.get("inprog") {
+        Some(Bson::Array(in_prog)) => in_prog,
+        _ => panic!("no `inprog` array found in response to `currentOp`"),
+    };
+
+    let metadata: Metadata = bson::from_bson(in_prog[0].clone()).unwrap();
+    assert_eq!(metadata.client.driver.name, DRIVER_NAME);
+}
+

--- a/tests/client/mod.rs
+++ b/tests/client/mod.rs
@@ -6,6 +6,7 @@ mod db;
 mod cursor;
 mod error;
 mod gridfs;
+mod handshake;
 mod wire_protocol;
 
 use bson;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -44,7 +44,23 @@ extern crate approx;
 extern crate bson;
 extern crate mongodb;
 extern crate rand;
+extern crate semver;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
 extern crate serde_json;
+
+#[macro_export]
+macro_rules! skip_if_db_version_below {
+    ($db:expr, $major:expr, $minor:expr) => {{
+        use mongodb::db::ThreadedDatabase;
+        use semver::Version;
+
+        if $db.version().unwrap() < Version::from(($major, $minor, 0)) {
+            return;
+        }
+    }};
+}
 
 mod apm;
 mod auth;


### PR DESCRIPTION
MongoDB has requested that we implement the [handshake spec](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.rst) for the driver so that they can identify users of the driver who are connected to Atlas. This is important so that the company can get some actual numbers on who is using the driver and whether it's worth investing more in it. This pull request implements the desired feature.

In addition to Kevin, I'm also asking @pmeredit to take a look at this just to get another pair of MongoDB eyes on the code. (It doesn't seem to allow me to add him as a reviewer because he's apparently not in the `mongodb-labs` organization, hence my @-mentioning him inline).