### PR TITLE
fix getMore batch size

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -405,7 +405,7 @@ impl Cursor {
         Ok(Cursor {
             client: client,
             namespace: namespace,
-            batch_size: options.batch_size.unwrap_or(DEFAULT_BATCH_SIZE),
+            batch_size: buf.len() as i32,
             cursor_id: cursor_id,
             limit: options.limit.unwrap_or(0) as i32,
             count: 0,

--- a/tests/client/batch_size.rs
+++ b/tests/client/batch_size.rs
@@ -1,0 +1,43 @@
+use mongodb::coll::Collection;
+use mongodb::cursor::Cursor;
+use mongodb::db::ThreadedDatabase;
+use mongodb::{Client, Result, ThreadedClient};
+
+fn test_batch_size<F>(coll_name: &str, query: F)
+where
+    F: Fn(&Collection) -> Result<Cursor>,
+{
+    let client = Client::connect("localhost", 27017).unwrap();
+    let db = client.db(coll_name);
+    let coll = db.collection("aggregate_batch_size");
+    coll.drop().unwrap();
+
+    let contents = (0..512).into_iter().map(|i| doc! { "x": i }).collect();
+    coll.insert_many(contents, None).unwrap();
+
+    let mut cursor = query(&coll).unwrap();
+
+    for _ in 0..(512 / 101) {
+        let batch = cursor.drain_current_batch().unwrap();
+        assert_eq!(101, batch.len());
+    }
+
+    let final_batch = cursor.drain_current_batch().unwrap();
+
+    println!("last: {}", final_batch.last().unwrap());
+
+    assert_eq!(512 % 101, final_batch.len());
+    assert!(cursor.next().is_none());
+}
+
+#[test]
+fn aggregate_batch_size() {
+    test_batch_size("aggregate_batch_size", |coll| {
+        coll.aggregate(Vec::new(), None)
+    });
+}
+
+#[test]
+fn find_batch_size() {
+    test_batch_size("find_batch_size", |coll| coll.find(None, None));
+}

--- a/tests/client/mod.rs
+++ b/tests/client/mod.rs
@@ -1,3 +1,4 @@
+mod batch_size;
 mod bulk;
 mod coll;
 mod connstring;


### PR DESCRIPTION
This fixes https://github.com/mongodb-labs/mongo-rust-driver-prototype/issues/245 (for real this time!)

After playing around with a few more complicated fixes, I realized that the best solution was dead simple: the batch size of the cursor should just be the the size of the first batch returned by the server. While this technically means that the cursor will contain an "incorrect" batch size when the result set is smaller than the calculated batch size, this won't cause any issues in practice since the field is private and by definition no more batches will be fetched.

For testing, the `Cursor::drain_current_batch` method conveniently lets us get the actual batch size without needing to expose any additional details. I verified that the tests failed without the fix being added, so I think we fixed the issue for real this time.

cc @nevi-me