### PR TITLE
Grand cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.3.10"
 
 [dependencies]
 bitflags = "1.0.0"
-bson = "0.12.2"
+bson = "0.13.0"
 bufstream = "0.1.3"
 byteorder = "1.0.0"
 chrono = "0.4.0"

--- a/src/apm/event.rs
+++ b/src/apm/event.rs
@@ -5,6 +5,7 @@ use error::Error as MongoError;
 use separator::Separatable;
 
 /// Contains the information about a given command that started.
+#[derive(Debug, Clone, PartialEq)]
 pub struct CommandStarted {
     pub command: Document,
     pub database_name: String,
@@ -15,16 +16,18 @@ pub struct CommandStarted {
 
 impl Display for CommandStarted {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        fmt.write_fmt(format_args!(
+        write!(
+            fmt,
             "COMMAND.{} {} STARTED: {}",
             self.command_name,
             self.connection_string,
             self.command
-        ))
+        )
     }
 }
 
 /// Contains the information about a given command that completed.
+#[derive(Debug, Clone)]
 pub enum CommandResult<'a> {
     Success {
         duration: u64,
@@ -52,13 +55,14 @@ impl<'a> Display for CommandResult<'a> {
                 ref connection_string,
                 ..
             } => {
-                fmt.write_fmt(format_args!(
+                write!(
+                    fmt,
                     "COMMAND.{} {} COMPLETED: {} ({} ns)",
                     command_name,
                     connection_string,
                     reply,
                     duration.separated_string()
-                ))
+                )
             }
             CommandResult::Failure {
                 duration,
@@ -67,13 +71,14 @@ impl<'a> Display for CommandResult<'a> {
                 ref connection_string,
                 ..
             } => {
-                fmt.write_fmt(format_args!(
+                write!(
+                    fmt,
                     "COMMAND.{} {} FAILURE: {} ({} ns)",
                     command_name,
                     connection_string,
                     failure,
                     duration.separated_string()
-                ))
+                )
             }
         }
     }

--- a/src/coll/batch.rs
+++ b/src/coll/batch.rs
@@ -4,7 +4,7 @@ use super::options::WriteModel;
 use bson::{Bson, Document};
 use std::convert::From;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DeleteModel {
     pub filter: Document,
     pub multi: bool,
@@ -19,7 +19,7 @@ impl DeleteModel {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct UpdateModel {
     pub filter: Document,
     pub update: Document,
@@ -63,7 +63,7 @@ impl From<UpdateModel> for Document {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Batch {
     Insert(Vec<Document>),
     Delete(Vec<DeleteModel>),

--- a/src/coll/error.rs
+++ b/src/coll/error.rs
@@ -6,7 +6,7 @@ use {Error, Result};
 use std::{error, fmt};
 
 /// The error type for Write-related MongoDB operations.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WriteException {
     pub write_concern_error: Option<WriteConcernError>,
     pub write_error: Option<WriteError>,
@@ -14,7 +14,7 @@ pub struct WriteException {
 }
 
 /// The error struct for a write-concern related error.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WriteConcernError {
     pub code: i32,
     pub details: WriteConcern,
@@ -22,14 +22,14 @@ pub struct WriteConcernError {
 }
 
 /// The error struct for a write-related error.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WriteError {
     pub code: i32,
     pub message: String,
 }
 
 /// The error struct for Bulk-Write related MongoDB operations.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BulkWriteException {
     pub processed_requests: Vec<WriteModel>,
     pub unprocessed_requests: Vec<WriteModel>,
@@ -40,7 +40,7 @@ pub struct BulkWriteException {
 
 /// The error struct for a single bulk-write step, indicating the request
 /// and its index in the original bulk-write request.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BulkWriteError {
     pub index: i32,
     pub code: i32,

--- a/src/coll/error.rs
+++ b/src/coll/error.rs
@@ -6,7 +6,7 @@ use {Error, Result};
 use std::{error, fmt};
 
 /// The error type for Write-related MongoDB operations.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct WriteException {
     pub write_concern_error: Option<WriteConcernError>,
     pub write_error: Option<WriteError>,
@@ -14,7 +14,7 @@ pub struct WriteException {
 }
 
 /// The error struct for a write-concern related error.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct WriteConcernError {
     pub code: i32,
     pub details: WriteConcern,
@@ -22,14 +22,14 @@ pub struct WriteConcernError {
 }
 
 /// The error struct for a write-related error.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct WriteError {
     pub code: i32,
     pub message: String,
 }
 
 /// The error struct for Bulk-Write related MongoDB operations.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct BulkWriteException {
     pub processed_requests: Vec<WriteModel>,
     pub unprocessed_requests: Vec<WriteModel>,
@@ -40,7 +40,7 @@ pub struct BulkWriteException {
 
 /// The error struct for a single bulk-write step, indicating the request
 /// and its index in the original bulk-write request.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct BulkWriteError {
     pub index: i32,
     pub code: i32,
@@ -52,34 +52,24 @@ impl error::Error for WriteException {
     fn description(&self) -> &str {
         &self.message
     }
-
-    fn cause(&self) -> Option<&error::Error> {
-        None
-    }
 }
 
 impl error::Error for BulkWriteException {
     fn description(&self) -> &str {
         &self.message
     }
-
-    fn cause(&self) -> Option<&error::Error> {
-        None
-    }
 }
 
 impl fmt::Display for WriteException {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let wc_err = &self.write_concern_error;
-        let w_err = &self.write_error;
+        fmt.write_str("WriteException:\n")?;
 
-        try!(write!(fmt, "WriteException:\n"));
-        if wc_err.is_some() {
-            try!(write!(fmt, "{:?}\n", wc_err));
+        if let Some(ref wc_err) = self.write_concern_error {
+            write!(fmt, "{:?}\n", wc_err)?;
         }
 
-        if w_err.is_some() {
-            try!(write!(fmt, "{:?}\n", w_err));
+        if let Some(ref w_err) = self.write_error {
+            write!(fmt, "{:?}\n", w_err)?;
         }
 
         Ok(())
@@ -88,24 +78,24 @@ impl fmt::Display for WriteException {
 
 impl fmt::Display for BulkWriteException {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(fmt, "BulkWriteException:\n"));
+        fmt.write_str("BulkWriteException:\n")?;
 
-        try!(write!(fmt, "Processed Requests:\n"));
+        fmt.write_str("Processed Requests:\n")?;
         for v in &self.processed_requests {
-            try!(write!(fmt, "{:?}\n", v));
+            write!(fmt, "{:?}\n", v)?;
         }
 
-        try!(write!(fmt, "Unprocessed Requests:\n"));
+        fmt.write_str("Unprocessed Requests:\n")?;
         for v in &self.unprocessed_requests {
-            try!(write!(fmt, "{:?}\n", v));
+            write!(fmt, "{:?}\n", v)?;
         }
 
         if let Some(ref error) = self.write_concern_error {
-            try!(write!(fmt, "{:?}\n", error));
+            write!(fmt, "{:?}\n", error)?;
         }
 
         for v in &self.write_errors {
-            try!(write!(fmt, "{:?}\n", v));
+            write!(fmt, "{:?}\n", v)?;
         }
 
         Ok(())
@@ -114,55 +104,44 @@ impl fmt::Display for BulkWriteException {
 
 impl fmt::Display for BulkWriteError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(
+        write!(
             fmt,
             "BulkWriteError at index {} (code {}): {}\n",
             self.index,
             self.code,
             self.message
-        ));
+        )?;
 
         match self.request {
-            Some(ref request) => try!(write!(fmt, "Failed to execute request {:?}\n.", request)),
-            None => {
-                try!(write!(
-                    fmt,
-                    "No additional error information was received.\n"
-                ))
-            }
+            Some(ref request) => write!(fmt, "Failed to execute request {:?}\n.", request),
+            None => fmt.write_str("No additional error information was received.\n")
         }
-
-        Ok(())
     }
 }
 
 impl WriteException {
     /// Returns a new WriteException containing the given errors.
     pub fn new(wc_err: Option<WriteConcernError>, w_err: Option<WriteError>) -> WriteException {
-        let mut s = match wc_err {
-            Some(ref error) => format!("{:?}\n", error),
-            None => String::from(""),
-        };
+        use std::fmt::Write;
+
+        let mut s = wc_err.as_ref().map(|error| format!("{:?}\n", error)).unwrap_or_default();
 
         if let Some(ref error) = w_err {
-            s.push_str(&format!("{:?}\n", error)[..]);
+            write!(s, "{:?}\n", error).expect("can't format error");
         }
 
         WriteException {
             write_concern_error: wc_err,
             write_error: w_err,
-            message: String::from(s),
+            message: s,
         }
     }
 
     /// Downgrades a BulkWriteException into a WriteException, retrieving the
     /// last write error to emulate the behavior of continue_on_error.
     pub fn with_bulk_exception(bulk_exception: BulkWriteException) -> WriteException {
-        let len = bulk_exception.write_errors.len();
-        let write_error = match bulk_exception.write_errors.get(len - 1) {
-            Some(e) => Some(WriteError::new(e.code, e.message.to_owned())),
-            None => None,
-        };
+        let mut write_errors = bulk_exception.write_errors;
+        let write_error = write_errors.pop().map(|e| WriteError::new(e.code, e.message));
 
         WriteException::new(bulk_exception.write_concern_error, write_error)
     }
@@ -200,9 +179,9 @@ impl WriteConcernError {
 
     /// Parses a Bson document into a WriteConcernError with the provided write concern.
     pub fn parse(error: bson::Document, write_concern: WriteConcern) -> Result<WriteConcernError> {
-        if let Some(&Bson::I32(ref code)) = error.get("code") {
+        if let Some(&Bson::I32(code)) = error.get("code") {
             if let Some(&Bson::String(ref message)) = error.get("errmsg") {
-                return Ok(WriteConcernError::new(*code, write_concern, message));
+                return Ok(WriteConcernError::new(code, write_concern, message));
             }
         }
         Err(Error::ResponseError(format!(
@@ -223,9 +202,9 @@ impl WriteError {
 
     /// Parses a Bson document into a WriteError.
     pub fn parse(error: bson::Document) -> Result<WriteError> {
-        if let Some(&Bson::I32(ref code)) = error.get("code") {
+        if let Some(&Bson::I32(code)) = error.get("code") {
             if let Some(&Bson::String(ref message)) = error.get("errmsg") {
-                return Ok(WriteError::new(*code, message));
+                return Ok(WriteError::new(code, message));
             }
         }
         Err(Error::ResponseError(
@@ -252,10 +231,10 @@ impl BulkWriteError {
 
     /// Parses a Bson document into a BulkWriteError.
     pub fn parse(error: bson::Document) -> Result<BulkWriteError> {
-        if let Some(&Bson::I32(ref index)) = error.get("index") {
-            if let Some(&Bson::I32(ref code)) = error.get("code") {
+        if let Some(&Bson::I32(index)) = error.get("index") {
+            if let Some(&Bson::I32(code)) = error.get("code") {
                 if let Some(&Bson::String(ref message)) = error.get("errmsg") {
-                    return Ok(BulkWriteError::new(*index, *code, message, None));
+                    return Ok(BulkWriteError::new(index, code, message, None));
                 }
             }
         }
@@ -273,14 +252,15 @@ impl BulkWriteException {
         write_errors: Vec<BulkWriteError>,
         write_concern_error: Option<WriteConcernError>,
     ) -> BulkWriteException {
+        use std::fmt::Write;
 
         let mut s = match write_concern_error {
             Some(ref error) => format!("{:?}\n", error),
-            None => String::from(""),
+            None => String::new(),
         };
 
         for v in &write_errors {
-            s.push_str(&format!("{:?}\n", v)[..]);
+            write!(s, "{:?}\n", v).expect("can't format error");
         }
 
         BulkWriteException {
@@ -288,7 +268,7 @@ impl BulkWriteException {
             unprocessed_requests: unprocessed,
             write_concern_error: write_concern_error,
             write_errors: write_errors,
-            message: String::from(s),
+            message: s,
         }
     }
 
@@ -345,7 +325,7 @@ impl BulkWriteException {
 
         // Parse out any write concern errors.
         let wc_err = if let Some(&Bson::Document(ref error)) = result.get("writeConcernError") {
-            Some(try!(WriteConcernError::parse(error.clone(), write_concern)))
+            Some(WriteConcernError::parse(error.clone(), write_concern)?)
         } else {
             None
         };
@@ -361,7 +341,7 @@ impl BulkWriteException {
             let mut vec = Vec::new();
             for err in errors {
                 if let Bson::Document(ref doc) = *err {
-                    vec.push(try!(BulkWriteError::parse(doc.clone())));
+                    vec.push(BulkWriteError::parse(doc.clone())?);
                 } else {
                     return Err(Error::ResponseError(
                         String::from("WriteError provided was not a bson document."),

--- a/src/coll/error.rs
+++ b/src/coll/error.rs
@@ -6,7 +6,7 @@ use {Error, Result};
 use std::{error, fmt};
 
 /// The error type for Write-related MongoDB operations.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct WriteException {
     pub write_concern_error: Option<WriteConcernError>,
     pub write_error: Option<WriteError>,
@@ -14,7 +14,7 @@ pub struct WriteException {
 }
 
 /// The error struct for a write-concern related error.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct WriteConcernError {
     pub code: i32,
     pub details: WriteConcern,
@@ -22,14 +22,14 @@ pub struct WriteConcernError {
 }
 
 /// The error struct for a write-related error.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct WriteError {
     pub code: i32,
     pub message: String,
 }
 
 /// The error struct for Bulk-Write related MongoDB operations.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct BulkWriteException {
     pub processed_requests: Vec<WriteModel>,
     pub unprocessed_requests: Vec<WriteModel>,
@@ -40,7 +40,7 @@ pub struct BulkWriteException {
 
 /// The error struct for a single bulk-write step, indicating the request
 /// and its index in the original bulk-write request.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct BulkWriteError {
     pub index: i32,
     pub code: i32,

--- a/src/coll/error.rs
+++ b/src/coll/error.rs
@@ -65,11 +65,11 @@ impl fmt::Display for WriteException {
         fmt.write_str("WriteException:\n")?;
 
         if let Some(ref wc_err) = self.write_concern_error {
-            writeln!(fmt, "{:?}", wc_err)?;
+            write!(fmt, "{:?}", wc_err)?;
         }
 
         if let Some(ref w_err) = self.write_error {
-            writeln!(fmt, "{:?}", w_err)?;
+            write!(fmt, "{:?}", w_err)?;
         }
 
         Ok(())
@@ -82,20 +82,20 @@ impl fmt::Display for BulkWriteException {
 
         fmt.write_str("Processed Requests:\n")?;
         for v in &self.processed_requests {
-            write!(fmt, "{:?}\n", v)?;
+            write!(fmt, "{:?}", v)?;
         }
 
         fmt.write_str("Unprocessed Requests:\n")?;
         for v in &self.unprocessed_requests {
-            write!(fmt, "{:?}\n", v)?;
+            write!(fmt, "{:?}", v)?;
         }
 
         if let Some(ref error) = self.write_concern_error {
-            write!(fmt, "{:?}\n", error)?;
+            write!(fmt, "{:?}", error)?;
         }
 
         for v in &self.write_errors {
-            write!(fmt, "{:?}\n", v)?;
+            write!(fmt, "{:?}", v)?;
         }
 
         Ok(())
@@ -106,15 +106,15 @@ impl fmt::Display for BulkWriteError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(
             fmt,
-            "BulkWriteError at index {} (code {}): {}\n",
+            "BulkWriteError at index {} (code {}): {}",
             self.index,
             self.code,
             self.message
         )?;
 
         match self.request {
-            Some(ref request) => writeln!(fmt, "Failed to execute request {:?}.", request),
-            None => fmt.write_str("No additional error information was received.\n")
+            Some(ref request) => write!(fmt, "Failed to execute request {:?}.", request),
+            None => fmt.write_str("No additional error information was received.")
         }
     }
 }
@@ -124,10 +124,10 @@ impl WriteException {
     pub fn new(wc_err: Option<WriteConcernError>, w_err: Option<WriteError>) -> WriteException {
         use std::fmt::Write;
 
-        let mut s = wc_err.as_ref().map(|error| format!("{:?}\n", error)).unwrap_or_default();
+        let mut s = wc_err.as_ref().map(|error| format!("{:?}", error)).unwrap_or_default();
 
         if let Some(ref error) = w_err {
-            writeln!(s, "{:?}", error).expect("can't format error");
+            write!(s, "{:?}", error).expect("can't format error");
         }
 
         WriteException {
@@ -255,11 +255,11 @@ impl BulkWriteException {
         use std::fmt::Write;
 
         let mut s = write_concern_error.as_ref()
-            .map(|e| format!("{:?}\n", e))
+            .map(|e| format!("{:?}", e))
             .unwrap_or_default();
 
         for v in &write_errors {
-            write!(s, "{:?}\n", v).expect("can't format error");
+            write!(s, "{:?}", v).expect("can't format error");
         }
 
         BulkWriteException {

--- a/src/coll/error.rs
+++ b/src/coll/error.rs
@@ -254,10 +254,9 @@ impl BulkWriteException {
     ) -> BulkWriteException {
         use std::fmt::Write;
 
-        let mut s = match write_concern_error {
-            Some(ref error) => format!("{:?}\n", error),
-            None => String::new(),
-        };
+        let mut s = write_concern_error.as_ref()
+            .map(|e| format!("{:?}\n", e))
+            .unwrap_or_default();
 
         for v in &write_errors {
             write!(s, "{:?}\n", v).expect("can't format error");

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -25,6 +25,7 @@ use std::collections::{BTreeMap, VecDeque};
 use std::iter::FromIterator;
 
 /// Interfaces with a MongoDB collection.
+#[derive(Debug)]
 pub struct Collection {
     /// A reference to the database that spawned this collection.
     pub db: Database,

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -839,7 +839,7 @@ impl Collection {
         let cmd = doc! {
             "update": self.name(),
             "updates": updates,
-			"ordered": ordered,
+            "ordered": ordered,
             "writeConcern": wc.to_bson()
         };
 

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -183,11 +183,11 @@ impl Collection {
             self.read_preference.clone()
         });
 
-        let result = try!(self.db.command(
+        let result = self.db.command(
             spec,
             CommandType::Distinct,
             Some(read_preference),
-        ));
+        )?;
         match result.get("values") {
             Some(&Bson::Array(ref vals)) => Ok(vals.to_owned()),
             _ => Err(ResponseError(
@@ -334,7 +334,7 @@ impl Collection {
         replacement: bson::Document,
         options: Option<FindOneAndUpdateOptions>,
     ) -> Result<Option<bson::Document>> {
-        try!(Collection::validate_replace(&replacement));
+        Collection::validate_replace(&replacement)?;
 
         let (max_time_ms, write_concern) = match options {
             Some(ref opts) => (opts.max_time_ms, opts.write_concern.clone()),

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -597,7 +597,7 @@ impl Collection {
         };
 
         let mut result = BulkWriteResult::new();
-        let mut exception = BulkWriteException::default();
+        let mut exception = BulkWriteException::new(Vec::new(), Vec::new(), Vec::new(), None);
 
         let mut start_index = 0;
 

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -348,7 +348,7 @@ impl IndexModel {
     pub fn name(&self) -> Result<String> {
         Ok(match self.options.name {
             Some(ref name) => name.to_owned(),
-            None => try!(self.generate_index_name()),
+            None => self.generate_index_name()?,
         })
     }
 

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -58,7 +58,7 @@ pub enum WriteModel {
 }
 
 /// Options for aggregation queries.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AggregateOptions {
     pub allow_disk_use: Option<bool>,
     pub use_cursor: Option<bool>,
@@ -141,7 +141,7 @@ impl From<CountOptions> for bson::Document {
 }
 
 /// Options for distinct queries.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DistinctOptions {
     pub max_time_ms: Option<i64>,
     pub read_preference: Option<ReadPreference>,

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -5,7 +5,7 @@ use Error::ArgumentError;
 use Result;
 
 /// Describes the type of cursor to return on collection queries.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum CursorType {
     NonTailable,
     Tailable,
@@ -19,7 +19,7 @@ impl Default for CursorType {
 }
 
 /// Describes the type of document to return on write operations.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ReturnDocument {
     Before,
     After,
@@ -35,7 +35,7 @@ impl ReturnDocument {
 }
 
 /// Marker interface for writes that can be batched together.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum WriteModel {
     InsertOne { document: bson::Document },
     DeleteOne { filter: bson::Document },
@@ -58,7 +58,7 @@ pub enum WriteModel {
 }
 
 /// Options for aggregation queries.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct AggregateOptions {
     pub allow_disk_use: Option<bool>,
     pub use_cursor: Option<bool>,
@@ -78,14 +78,14 @@ impl From<AggregateOptions> for bson::Document {
         let mut document = bson::Document::new();
 
         if let Some(allow_disk_use) = options.allow_disk_use {
-            document.insert("allowDiskUse", Bson::Boolean(allow_disk_use));
+            document.insert("allowDiskUse", allow_disk_use);
         }
 
         // useCursor not currently used by the driver.
 
 
         let cursor = doc! { "batchSize": options.batch_size };
-        document.insert("cursor", Bson::Document(cursor));
+        document.insert("cursor", cursor);
 
         // maxTimeMS is not currently used by the driver.
 
@@ -96,7 +96,7 @@ impl From<AggregateOptions> for bson::Document {
 }
 
 /// Options for count queries.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct CountOptions {
     pub skip: Option<i64>,
     pub limit: Option<i64>,
@@ -117,19 +117,19 @@ impl From<CountOptions> for bson::Document {
         let mut document = bson::Document::new();
 
         if let Some(skip) = options.skip {
-            document.insert("skip", Bson::I64(skip));
+            document.insert("skip", skip);
         }
 
         if let Some(limit) = options.limit {
-            document.insert("limit", Bson::I64(limit));
+            document.insert("limit", limit);
         }
 
         if let Some(hint) = options.hint {
-            document.insert("hint", Bson::String(hint));
+            document.insert("hint", hint);
         }
 
         if let Some(hint_doc) = options.hint_doc {
-            document.insert("hint_doc", Bson::Document(hint_doc));
+            document.insert("hint_doc", hint_doc);
         }
 
         // maxTimeMS is not currently used by the driver.
@@ -141,7 +141,7 @@ impl From<CountOptions> for bson::Document {
 }
 
 /// Options for distinct queries.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct DistinctOptions {
     pub max_time_ms: Option<i64>,
     pub read_preference: Option<ReadPreference>,
@@ -154,7 +154,7 @@ impl DistinctOptions {
 }
 
 /// Options for collection queries.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct FindOptions {
     pub allow_partial_results: bool,
     pub no_cursor_timeout: bool,
@@ -190,23 +190,23 @@ impl From<FindOptions> for bson::Document {
         // read_preference is used directly by Collection::find_with_command_type.
 
         if let Some(projection) = options.projection {
-            document.insert("projection", Bson::Document(projection));
+            document.insert("projection", projection);
         }
 
         if let Some(skip) = options.skip {
-            document.insert("skip", Bson::I64(skip));
+            document.insert("skip", skip);
         }
 
         if let Some(limit) = options.limit {
-            document.insert("limit", Bson::I64(limit));
+            document.insert("limit", limit);
         }
 
         if let Some(batch_size) = options.batch_size {
-            document.insert("batchSize", Bson::I32(batch_size));
+            document.insert("batchSize", batch_size);
         }
 
         if let Some(sort) = options.sort {
-            document.insert("sort", Bson::Document(sort));
+            document.insert("sort", sort);
         }
 
         document
@@ -214,7 +214,7 @@ impl From<FindOptions> for bson::Document {
 }
 
 /// Options for `findOneAndDelete` operations.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct FindOneAndDeleteOptions {
     pub max_time_ms: Option<i64>,
     pub projection: Option<bson::Document>,
@@ -235,15 +235,15 @@ impl From<FindOneAndDeleteOptions> for bson::Document {
         // max_time_ms is not currently used by the driver
 
         if let Some(projection) = options.projection {
-            document.insert("fields", Bson::Document(projection));
+            document.insert("fields", projection);
         }
 
         if let Some(sort) = options.sort {
-            document.insert("sort", Bson::Document(sort));
+            document.insert("sort", sort);
         }
 
         if let Some(write_concern) = options.write_concern {
-            document.insert("writeConcern", Bson::Document(write_concern.to_bson()));
+            document.insert("writeConcern", write_concern.to_bson());
         }
 
         document
@@ -251,7 +251,7 @@ impl From<FindOneAndDeleteOptions> for bson::Document {
 }
 
 /// Options for `findOneAndUpdate` operations.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct FindOneAndUpdateOptions {
     pub return_document: Option<ReturnDocument>,
     pub max_time_ms: Option<i64>,
@@ -272,17 +272,17 @@ impl From<FindOneAndUpdateOptions> for bson::Document {
         let mut document = bson::Document::new();
 
         if let Some(return_document) = options.return_document {
-            document.insert("new", Bson::Boolean(return_document.as_bool()));
+            document.insert("new", return_document.as_bool());
         }
 
         // max_time_ms is not currently used by the driver
 
         if let Some(projection) = options.projection {
-            document.insert("fields", Bson::Document(projection));
+            document.insert("fields", projection);
         }
 
         if let Some(sort) = options.sort {
-            document.insert("sort", Bson::Document(sort));
+            document.insert("sort", sort);
         }
 
         if let Some(upsert) = options.upsert {
@@ -290,7 +290,7 @@ impl From<FindOneAndUpdateOptions> for bson::Document {
         }
 
         if let Some(write_concern) = options.write_concern {
-            document.insert("writeConcern", Bson::Document(write_concern.to_bson()));
+            document.insert("writeConcern", write_concern.to_bson());
         }
 
         document
@@ -298,7 +298,7 @@ impl From<FindOneAndUpdateOptions> for bson::Document {
 }
 
 /// Options for index operations.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct IndexOptions {
     pub background: Option<bool>,
     pub expire_after_seconds: Option<i32>,
@@ -329,7 +329,7 @@ impl IndexOptions {
 }
 
 /// A single index model.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct IndexModel {
     pub keys: bson::Document,
     pub options: IndexOptions,
@@ -381,58 +381,57 @@ impl IndexModel {
 
     /// Converts the model to its BSON document representation.
     pub fn to_bson(&self) -> Result<bson::Document> {
-        let mut doc = bson::Document::new();
-        doc.insert("key", Bson::Document(self.keys.clone()));
+        let mut doc = doc!{ "key": self.keys.clone() };
 
-        if let Some(ref val) = self.options.background {
-            doc.insert("background", Bson::Boolean(*val));
+        if let Some(val) = self.options.background {
+            doc.insert("background", val);
         }
-        if let Some(ref val) = self.options.expire_after_seconds {
-            doc.insert("expireAfterSeconds", Bson::I32(*val));
+        if let Some(val) = self.options.expire_after_seconds {
+            doc.insert("expireAfterSeconds", val);
         }
         if let Some(ref val) = self.options.name {
-            doc.insert("name", Bson::String(val.to_owned()));
+            doc.insert("name", val);
         } else {
-            doc.insert("name", Bson::String(try!(self.generate_index_name())));
+            doc.insert("name", self.generate_index_name()?);
         }
-        if let Some(ref val) = self.options.sparse {
-            doc.insert("sparse", Bson::Boolean(*val));
+        if let Some(val) = self.options.sparse {
+            doc.insert("sparse", val);
         }
         if let Some(ref val) = self.options.storage_engine {
-            doc.insert("storageEngine", Bson::String(val.to_owned()));
+            doc.insert("storageEngine", val);
         }
-        if let Some(ref val) = self.options.unique {
-            doc.insert("unique", Bson::Boolean(*val));
+        if let Some(val) = self.options.unique {
+            doc.insert("unique", val);
         }
-        if let Some(ref val) = self.options.version {
-            doc.insert("v", Bson::I32(*val));
+        if let Some(val) = self.options.version {
+            doc.insert("v", val);
         }
         if let Some(ref val) = self.options.default_language {
-            doc.insert("default_language", Bson::String(val.to_owned()));
+            doc.insert("default_language", val);
         }
         if let Some(ref val) = self.options.language_override {
-            doc.insert("language_override", Bson::String(val.to_owned()));
+            doc.insert("language_override", val);
         }
-        if let Some(ref val) = self.options.text_version {
-            doc.insert("textIndexVersion", Bson::I32(*val));
+        if let Some(val) = self.options.text_version {
+            doc.insert("textIndexVersion", val);
         }
         if let Some(ref val) = self.options.weights {
-            doc.insert("weights", Bson::Document(val.clone()));
+            doc.insert("weights", val.clone());
         }
-        if let Some(ref val) = self.options.sphere_version {
-            doc.insert("2dsphereIndexVersion", Bson::I32(*val));
+        if let Some(val) = self.options.sphere_version {
+            doc.insert("2dsphereIndexVersion", val);
         }
-        if let Some(ref val) = self.options.bits {
-            doc.insert("bits", Bson::I32(*val));
+        if let Some(val) = self.options.bits {
+            doc.insert("bits", val);
         }
-        if let Some(ref val) = self.options.max {
-            doc.insert("max", Bson::FloatingPoint(*val));
+        if let Some(val) = self.options.max {
+            doc.insert("max", val);
         }
-        if let Some(ref val) = self.options.min {
-            doc.insert("min", Bson::FloatingPoint(*val));
+        if let Some(val) = self.options.min {
+            doc.insert("min", val);
         }
-        if let Some(ref val) = self.options.bucket_size {
-            doc.insert("bucketSize", Bson::I32(*val));
+        if let Some(val) = self.options.bucket_size {
+            doc.insert("bucketSize", val);
         }
 
         Ok(doc)
@@ -440,7 +439,7 @@ impl IndexModel {
 }
 
 /// Options for insertMany operations.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct InsertManyOptions {
     pub ordered: Option<bool>,
     pub write_concern: Option<WriteConcern>,
@@ -457,11 +456,11 @@ impl From<InsertManyOptions> for bson::Document {
         let mut document = bson::Document::new();
 
         if let Some(ordered) = options.ordered {
-            document.insert("ordered", Bson::Boolean(ordered));
+            document.insert("ordered", ordered);
         }
 
         if let Some(write_concern) = options.write_concern {
-            document.insert("writeConcern", Bson::Document(write_concern.to_bson()));
+            document.insert("writeConcern", write_concern.to_bson());
         }
 
         document
@@ -469,7 +468,7 @@ impl From<InsertManyOptions> for bson::Document {
 }
 
 /// Options for update operations.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct UpdateOptions {
     pub upsert: Option<bool>,
     pub write_concern: Option<WriteConcern>,

--- a/src/coll/results.rs
+++ b/src/coll/results.rs
@@ -6,7 +6,7 @@ use super::error::{BulkWriteException, WriteException};
 use super::options::WriteModel;
 
 /// Results for a bulk write operation.
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct BulkWriteResult {
     pub acknowledged: bool,
     pub inserted_count: i32,
@@ -20,7 +20,7 @@ pub struct BulkWriteResult {
 }
 
 /// Results for a bulk delete operation.
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BulkDeleteResult {
     pub acknowledged: bool,
     pub deleted_count: i32,
@@ -28,7 +28,7 @@ pub struct BulkDeleteResult {
 }
 
 /// Results for a bulk update operation.
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BulkUpdateResult {
     pub acknowledged: bool,
     pub matched_count: i32,
@@ -38,7 +38,7 @@ pub struct BulkUpdateResult {
 }
 
 /// Results for an insertOne operation.
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InsertOneResult {
     pub acknowledged: bool,
     pub inserted_id: Option<Bson>,
@@ -46,7 +46,7 @@ pub struct InsertOneResult {
 }
 
 /// Results for an insertMany operation.
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InsertManyResult {
     pub acknowledged: bool,
     pub inserted_ids: Option<BTreeMap<i64, Bson>>,
@@ -54,7 +54,7 @@ pub struct InsertManyResult {
 }
 
 /// Results for a deletion operation.
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DeleteResult {
     pub acknowledged: bool,
     pub deleted_count: i32,
@@ -62,7 +62,7 @@ pub struct DeleteResult {
 }
 
 /// Results for an update operation.
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct UpdateResult {
     pub acknowledged: bool,
     pub matched_count: i32,

--- a/src/command_type.rs
+++ b/src/command_type.rs
@@ -1,7 +1,7 @@
 //! Monitorable command types.
 
 /// Executable command types that can be monitored by the driver.
-#[derive(PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum CommandType {
     Aggregate,
     BuildInfo,

--- a/src/common.rs
+++ b/src/common.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 use std::str::FromStr;
 
 /// Indicates how a server should be selected during read operations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ReadMode {
     Primary,
     PrimaryPreferred,
@@ -34,7 +34,7 @@ impl FromStr for ReadMode {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ReadPreference {
     /// Indicates how a server should be selected during read operations.
     pub mode: ReadMode,
@@ -68,7 +68,7 @@ impl ReadPreference {
     }
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WriteConcern {
     /// Write replication
     pub w: i32,

--- a/src/common.rs
+++ b/src/common.rs
@@ -68,7 +68,7 @@ impl ReadPreference {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WriteConcern {
     /// Write replication
     pub w: i32,
@@ -91,11 +91,17 @@ impl WriteConcern {
     }
 
     pub fn to_bson(&self) -> bson::Document {
-        let mut bson = bson::Document::new();
-        bson.insert("w", Bson::I32(self.w));
-        bson.insert("wtimeout", Bson::I32(self.w_timeout));
-        bson.insert("j", Bson::Boolean(self.j));
-        bson
+        doc! {
+            "w": self.w,
+            "wtimeout": self.w_timeout,
+            "j": self.j,
+        }
+    }
+}
+
+impl Default for WriteConcern {
+    fn default() -> Self {
+        WriteConcern::new()
     }
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -34,7 +34,7 @@ impl FromStr for ReadMode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReadPreference {
     /// Indicates how a server should be selected during read operations.
     pub mode: ReadMode,

--- a/src/connstring.rs
+++ b/src/connstring.rs
@@ -41,7 +41,7 @@ impl Host {
 }
 
 /// Encapsulates the options and read preference tags of a MongoDB connection.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ConnectionOptions {
     pub options: BTreeMap<String, String>,
     pub read_pref_tags: Vec<String>,
@@ -265,8 +265,8 @@ fn split_hosts(host_str: &str) -> Result<Vec<Host>> {
 
 // Parses the delimited string into its options and Read Preference Tags.
 fn parse_options(opts: &str, delim: Option<&str>) -> ConnectionOptions {
-    let mut options: BTreeMap<String, String> = BTreeMap::new();
-    let mut read_pref_tags: Vec<String> = Vec::new();
+    let mut options = BTreeMap::new();
+    let mut read_pref_tags = Vec::new();
 
     // Split and collect options into a vec
     let opt_list = match delim {

--- a/src/connstring.rs
+++ b/src/connstring.rs
@@ -139,12 +139,12 @@ pub fn parse(address: &str) -> Result<ConnectionString> {
     // Split on authentication and hosts
     if host_str.contains('@') {
         let (user_info, host_string) = rpartition(host_str, "@");
-        let (u, p) = try!(parse_user_info(user_info));
+        let (u, p) = parse_user_info(user_info)?;
         user = Some(String::from(u));
         password = Some(String::from(p));
-        hosts = try!(split_hosts(host_string));
+        hosts = split_hosts(host_string)?;
     } else {
-        hosts = try!(split_hosts(host_str));
+        hosts = split_hosts(host_str)?;
     }
 
     let mut opts = "";
@@ -257,7 +257,7 @@ fn split_hosts(host_str: &str) -> Result<Vec<Host>> {
                 String::from("Empty host, or extra comma in host list."),
             ));
         }
-        let host = try!(parse_host(entity));
+        let host = parse_host(entity)?;
         hosts.push(host);
     }
     Ok(hosts)

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -37,7 +37,7 @@ use wire_protocol::operations::Message;
 use std::collections::vec_deque::VecDeque;
 
 // Allows the server to decide the batch size.
-pub const DEFAULT_BATCH_SIZE: i32 = 0;
+pub const DEFAULT_BATCH_SIZE: usize = 0;
 
 /// Maintains a connection to the server and lazily returns documents from a
 /// query.
@@ -48,7 +48,7 @@ pub struct Cursor {
     // The namespace to read and write from.
     namespace: String,
     // How many documents to fetch at a given time from the server.
-    batch_size: i32,
+    batch_size: usize,
     // Uniquely identifies the cursor being returned by the reply.
     cursor_id: i64,
     // An upper bound on the total number of documents this cursor should return.
@@ -304,7 +304,7 @@ impl Cursor {
             flags,
             namespace.clone(),
             options.skip.unwrap_or(0) as i32,
-            options.batch_size.unwrap_or(DEFAULT_BATCH_SIZE),
+            options.batch_size.unwrap_or(DEFAULT_BATCH_SIZE as i32),
             query,
             options.projection,
         )?;
@@ -391,7 +391,7 @@ impl Cursor {
         Ok(Cursor {
             client: client,
             namespace: namespace,
-            batch_size: buf.len() as i32,
+            batch_size: buf.len(),
             cursor_id: cursor_id,
             limit: options.limit.unwrap_or(0) as i32,
             count: 0,
@@ -409,7 +409,7 @@ impl Cursor {
         let get_more = Message::new_get_more(
             req_id,
             self.namespace.to_owned(),
-            self.batch_size,
+            self.batch_size as i32,
             self.cursor_id,
         );
 
@@ -458,8 +458,7 @@ impl Cursor {
     /// # Return value
     ///
     /// Returns a vector containing the BSON documents that were read.
-    pub fn next_n(&mut self, n: i32) -> Result<Vec<bson::Document>> {
-        let n = ::std::cmp::max(0, n) as usize;
+    pub fn next_n(&mut self, n: usize) -> Result<Vec<bson::Document>> {
         self.take(n).collect()
     }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -327,7 +327,9 @@ impl ThreadedDatabase for Database {
             doc = merge_options(doc, create_collection_options);
         }
 
-        self.command(doc, CommandType::CreateCollection, None).map(drop)
+        self.command(doc, CommandType::CreateCollection, None)?;
+
+        Ok(())
     }
 
     fn create_user(

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -270,10 +270,11 @@ impl ThreadedDatabase for Database {
         batch_size: i32,
     ) -> Result<Cursor> {
 
-        let cursor = doc!{ "batchSize": batch_size };
         let mut spec = doc!{
             "listCollections": 1,
-            "cursor": cursor,
+            "cursor": {
+                "batchSize": batch_size,
+            },
         };
         if let Some(f) = filter {
             spec.insert("filter", f);

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -261,7 +261,7 @@ impl ThreadedDatabase for Database {
     }
 
     fn list_collections(&self, filter: Option<bson::Document>) -> Result<Cursor> {
-        self.list_collections_with_batch_size(filter, DEFAULT_BATCH_SIZE as i32)
+        self.list_collections_with_batch_size(filter, DEFAULT_BATCH_SIZE)
     }
 
     fn list_collections_with_batch_size(

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -73,6 +73,7 @@ use std::error::Error;
 use std::sync::Arc;
 
 /// Interfaces with a MongoDB database.
+#[derive(Debug)]
 pub struct DatabaseInner {
     /// The database name.
     pub name: String,
@@ -244,14 +245,16 @@ impl ThreadedDatabase for Database {
     ) -> Result<bson::Document> {
 
         let coll = self.collection("$cmd");
-        let mut options = FindOptions::new();
-        options.batch_size = Some(1);
-        options.read_preference = read_preference;
-        let res = try!(coll.find_one_with_command_type(
+        let options = FindOptions {
+            batch_size: Some(1),
+            read_preference: read_preference,
+            ..FindOptions::new()
+        };
+        let res = coll.find_one_with_command_type(
             Some(spec.clone()),
             Some(options),
             cmd_type,
-        ));
+        )?;
         res.ok_or_else(|| {
             OperationError(format!("Failed to execute command with spec {:?}.", spec))
         })
@@ -267,14 +270,13 @@ impl ThreadedDatabase for Database {
         batch_size: i32,
     ) -> Result<Cursor> {
 
-        let mut spec = bson::Document::new();
-        let mut cursor = bson::Document::new();
-
-        cursor.insert("batchSize", Bson::I32(batch_size));
-        spec.insert("listCollections", Bson::I32(1));
-        spec.insert("cursor", Bson::Document(cursor));
-        if filter.is_some() {
-            spec.insert("filter", Bson::Document(filter.unwrap()));
+        let cursor = doc!{ "batchSize": batch_size };
+        let mut spec = doc!{
+            "listCollections": 1,
+            "cursor": cursor,
+        };
+        if let Some(f) = filter {
+            spec.insert("filter", f);
         }
 
         self.command_cursor(
@@ -285,24 +287,20 @@ impl ThreadedDatabase for Database {
     }
 
     fn collection_names(&self, filter: Option<bson::Document>) -> Result<Vec<String>> {
-        let mut cursor = try!(self.list_collections(filter));
-        let mut results = vec![];
-        loop {
-            match cursor.next() {
-                Some(Ok(doc)) => {
-                    if let Some(&Bson::String(ref name)) = doc.get("name") {
-                        results.push(name.to_owned());
-                    }
+        self.list_collections(filter)?
+            .filter_map(|result| match result {
+                Err(err) => Some(Err(err)),
+                Ok(mut doc) => match doc.remove("name") {
+                    Some(Bson::String(name)) => Some(Ok(name)),
+                    _ => None,
                 }
-                Some(Err(err)) => return Err(err),
-                None => return Ok(results),
-            }
-        }
+            })
+            .collect()
     }
 
     fn version(&self) -> Result<Version> {
         let doc = doc! { "buildinfo": 1 };
-        let out = try!(self.command(doc, CommandType::BuildInfo, None));
+        let out = self.command(doc, CommandType::BuildInfo, None)?;
 
         match out.get("version") {
             Some(&Bson::String(ref s)) => {
@@ -328,9 +326,7 @@ impl ThreadedDatabase for Database {
             doc = merge_options(doc, create_collection_options);
         }
 
-        self.command(doc, CommandType::CreateCollection, None).map(
-            |_| (),
-        )
+        self.command(doc, CommandType::CreateCollection, None).map(drop)
     }
 
     fn create_user(
@@ -339,8 +335,7 @@ impl ThreadedDatabase for Database {
         password: &str,
         options: Option<CreateUserOptions>,
     ) -> Result<()> {
-        let mut doc =
-            doc! {
+        let mut doc = doc! {
             "createUser": name,
             "pwd": password
         };
@@ -350,21 +345,21 @@ impl ThreadedDatabase for Database {
                 doc = merge_options(doc, user_options);
             }
             None => {
-                doc.insert("roles", Bson::Array(Vec::new()));
+                doc.insert("roles", Vec::new());
             }
         };
 
-        self.command(doc, CommandType::CreateUser, None).map(|_| ())
+        self.command(doc, CommandType::CreateUser, None).map(drop)
     }
 
     fn drop_all_users(&self, write_concern: Option<WriteConcern>) -> Result<(i32)> {
         let mut doc = doc! { "dropAllUsersFromDatabase": 1 };
 
         if let Some(concern) = write_concern {
-            doc.insert("writeConcern", Bson::Document(concern.to_bson()));
+            doc.insert("writeConcern", concern.to_bson());
         }
 
-        let response = try!(self.command(doc, CommandType::DropAllUsers, None));
+        let response = self.command(doc, CommandType::DropAllUsers, None)?;
 
         match response.get("n") {
             Some(&Bson::I32(i)) => Ok(i),
@@ -374,17 +369,13 @@ impl ThreadedDatabase for Database {
     }
 
     fn drop_collection(&self, name: &str) -> Result<()> {
-        let mut spec = bson::Document::new();
-        spec.insert("drop", Bson::String(String::from(name)));
-        try!(self.command(spec, CommandType::DropCollection, None));
-        Ok(())
+        let spec = doc!{ "drop": name };
+        self.command(spec, CommandType::DropCollection, None).map(drop)
     }
 
     fn drop_database(&self) -> Result<()> {
-        let mut spec = bson::Document::new();
-        spec.insert("dropDatabase", Bson::I32(1));
-        try!(self.command(spec, CommandType::DropDatabase, None));
-        Ok(())
+        let spec = doc!{ "dropDatabase": 1_i32 };
+        self.command(spec, CommandType::DropDatabase, None).map(drop)
     }
 
     fn drop_user(&self, name: &str, write_concern: Option<WriteConcern>) -> Result<()> {
@@ -394,39 +385,35 @@ impl ThreadedDatabase for Database {
             doc.insert("writeConcern", concern.to_bson());
         }
 
-        self.command(doc, CommandType::DropUser, None).map(|_| ())
+        self.command(doc, CommandType::DropUser, None).map(drop)
     }
 
     fn get_all_users(&self, show_credentials: bool) -> Result<Vec<bson::Document>> {
-        let doc =
-            doc! {
+        let doc = doc! {
             "usersInfo": 1,
             "showCredentials": show_credentials
         };
 
-        let out = try!(self.command(doc, CommandType::GetUsers, None));
+        let out = self.command(doc, CommandType::GetUsers, None)?;
+
         let vec = match out.get("users") {
             Some(&Bson::Array(ref vec)) => vec.clone(),
             _ => return Err(CursorNotFoundError),
         };
 
-        let mut users = vec![];
-
-        for bson in vec {
-            match bson {
-                Bson::Document(doc) => users.push(doc),
-                _ => return Err(CursorNotFoundError),
-            };
-        }
-
-        Ok(users)
+        vec.into_iter()
+            .map(|bson| match bson {
+                Bson::Document(doc) => Ok(doc),
+                _ => Err(CursorNotFoundError),
+            })
+            .collect()
     }
 
     fn get_user(&self, user: &str, options: Option<UserInfoOptions>) -> Result<bson::Document> {
         let mut doc = doc! {
             "usersInfo": {
                 "user": user,
-                "db": self.name.to_owned(),
+                "db": &self.name,
             },
         };
 
@@ -434,11 +421,7 @@ impl ThreadedDatabase for Database {
             doc = merge_options(doc, user_info_options);
         }
 
-        let out = match self.command(doc, CommandType::GetUser, None) {
-            Ok(doc) => doc,
-            Err(e) => return Err(e),
-        };
-
+        let out = self.command(doc, CommandType::GetUser, None)?;
         let users = match out.get("users") {
             Some(&Bson::Array(ref v)) => v.clone(),
             _ => return Err(CursorNotFoundError),
@@ -457,12 +440,10 @@ impl ThreadedDatabase for Database {
     ) -> Result<Vec<bson::Document>> {
         let vec: Vec<_> = users
             .into_iter()
-            .map(|user| {
-                bson!({
-                    "user": user,
-                    "db": self.name.to_owned(),
-                })
-            })
+            .map(|user| bson!({
+                "user": user,
+                "db": &self.name,
+            }))
             .collect();
 
         let mut doc = doc! { "usersInfo": vec };
@@ -471,21 +452,17 @@ impl ThreadedDatabase for Database {
             doc = merge_options(doc, user_info_options);
         }
 
-        let out = try!(self.command(doc, CommandType::GetUsers, None));
+        let out = self.command(doc, CommandType::GetUsers, None)?;
         let vec = match out.get("users") {
             Some(&Bson::Array(ref vec)) => vec.clone(),
             _ => return Err(CursorNotFoundError),
         };
 
-        let mut users = vec![];
-
-        for bson in vec {
-            match bson {
-                Bson::Document(doc) => users.push(doc),
-                _ => return Err(CursorNotFoundError),
-            };
-        }
-
-        Ok(users)
+        vec.into_iter()
+            .map(|bson| match bson {
+                Bson::Document(doc) => Ok(doc),
+                _ => Err(CursorNotFoundError),
+            })
+            .collect()
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -375,7 +375,7 @@ impl ThreadedDatabase for Database {
     }
 
     fn drop_database(&self) -> Result<()> {
-        let spec = doc!{ "dropDatabase": 1_i32 };
+        let spec = doc!{ "dropDatabase": 1 };
         self.command(spec, CommandType::DropDatabase, None).map(drop)
     }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -261,7 +261,7 @@ impl ThreadedDatabase for Database {
     }
 
     fn list_collections(&self, filter: Option<bson::Document>) -> Result<Cursor> {
-        self.list_collections_with_batch_size(filter, DEFAULT_BATCH_SIZE)
+        self.list_collections_with_batch_size(filter, DEFAULT_BATCH_SIZE as i32)
     }
 
     fn list_collections_with_batch_size(

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -39,7 +39,7 @@ impl From<CreateCollectionOptions> for Document {
             document.insert("max", Bson::I64(max));
         }
 
-        let mut flags = 0_i32;
+        let mut flags = 0;
 
         if let Some(true) = options.use_power_of_two_sizes {
             flags |= 1;

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -3,7 +3,7 @@ use bson::{Bson, Document};
 use common::WriteConcern;
 use db::roles::Role;
 
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct CreateCollectionOptions {
     pub capped: Option<bool>,
     pub auto_index_id: Option<bool>,
@@ -39,25 +39,25 @@ impl From<CreateCollectionOptions> for Document {
             document.insert("max", Bson::I64(max));
         }
 
-        let mut flags = 0;
+        let mut flags = 0_i32;
 
         if let Some(true) = options.use_power_of_two_sizes {
-            flags += 1;
+            flags |= 1;
         }
 
         if let Some(true) = options.no_padding {
-            flags += 2;
+            flags |= 2;
         }
 
-        if options.use_power_of_two_sizes.is_some() || options.no_padding.is_some() {
-            document.insert("flags", Bson::I32(flags));
+        if flags != 0 {
+            document.insert("flags", flags);
         }
 
         document
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone, Debug, PartialEq)]
 pub struct CreateUserOptions {
     pub custom_data: Option<Document>,
     pub roles: Vec<Role>,
@@ -78,19 +78,19 @@ impl From<CreateUserOptions> for Document {
             document.insert("customData", Bson::Document(custom_data));
         }
 
-        let roles_barr = options.roles.into_iter().map(|r| r.to_bson()).collect();
+        let roles_barr = options.roles.iter().map(Role::to_bson).collect();
 
         document.insert("roles", Bson::Array(roles_barr));
 
         if let Some(write_concern) = options.write_concern {
-            document.insert("writeConcern", Bson::Document(write_concern.to_bson()));
+            document.insert("writeConcern", write_concern.to_bson());
         }
 
         document
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct UserInfoOptions {
     pub show_credentials: Option<bool>,
     pub show_privileges: Option<bool>,
@@ -107,11 +107,11 @@ impl From<UserInfoOptions> for Document {
         let mut document = Document::new();
 
         if let Some(show_credentials) = options.show_credentials {
-            document.insert("showCredentials", Bson::Boolean(show_credentials));
+            document.insert("showCredentials", show_credentials);
         }
 
         if let Some(show_privileges) = options.show_privileges {
-            document.insert("showPrivileges", Bson::Boolean(show_privileges));
+            document.insert("showPrivileges", show_privileges);
         }
 
         document

--- a/src/db/roles.rs
+++ b/src/db/roles.rs
@@ -3,7 +3,7 @@ use std::string::ToString;
 
 use bson::Bson;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SingleDatabaseRole {
     Read,
     ReadWrite,
@@ -18,9 +18,9 @@ pub enum SingleDatabaseRole {
     Restore,
 }
 
-impl ToString for SingleDatabaseRole {
-    fn to_string(&self) -> String {
-        let string = match *self {
+impl SingleDatabaseRole {
+    fn to_str(&self) -> &'static str {
+        match *self {
             SingleDatabaseRole::Read => "read",
             SingleDatabaseRole::ReadWrite => "readWrite",
             SingleDatabaseRole::DbAdmin => "dbAdmin",
@@ -32,13 +32,17 @@ impl ToString for SingleDatabaseRole {
             SingleDatabaseRole::HostManager => "hostManager",
             SingleDatabaseRole::Backup => "backup",
             SingleDatabaseRole::Restore => "restore",
-        };
-
-        String::from(string)
+        }
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+impl ToString for SingleDatabaseRole {
+    fn to_string(&self) -> String {
+        self.to_str().into()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum AllDatabaseRole {
     Read,
     ReadWrite,
@@ -46,16 +50,20 @@ pub enum AllDatabaseRole {
     DbAdmin,
 }
 
-impl ToString for AllDatabaseRole {
-    fn to_string(&self) -> String {
-        let string = match *self {
+impl AllDatabaseRole {
+    fn to_str(&self) -> &'static str {
+        match *self {
             AllDatabaseRole::Read => "read",
             AllDatabaseRole::ReadWrite => "readWrite",
             AllDatabaseRole::UserAdmin => "userAdmin",
             AllDatabaseRole::DbAdmin => "dbAdmin",
-        };
+        }
+    }
+}
 
-        String::from(string)
+impl ToString for AllDatabaseRole {
+    fn to_string(&self) -> String {
+        self.to_str().into()
     }
 }
 
@@ -71,11 +79,11 @@ pub enum Role {
 impl From<Role> for Bson {
     fn from(role: Role) -> Bson {
         match role {
-            Role::All(role) => Bson::String(role.to_string()),
+            Role::All(role) => role.to_string().into(),
             Role::Single { role, db } => {
                 Bson::Document(doc! {
-                  "role": Bson::String(role.to_string()),
-                  "db": Bson::String(db)
+                  "role": role.to_string(),
+                  "db": db
               })
             }
         }
@@ -89,6 +97,6 @@ impl Role {
 
     #[deprecated(since = "0.2.4", note = "this method will be removed in the next major release")]
     pub fn to_bson_array(vec: Vec<Role>) -> Bson {
-        Bson::Array(vec.into_iter().map(|r| r.to_bson()).collect())
+        Bson::Array(vec.iter().map(Self::to_bson).collect())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,30 +8,27 @@ use std::{error, fmt, io, result, sync};
 /// `mongodb::Error`.
 pub type Result<T> = result::Result<T, Error>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MaliciousServerErrorType {
     InvalidRnonce,
     InvalidServerSignature,
     NoServerSignature,
 }
 
+impl MaliciousServerErrorType {
+    fn to_str(&self) -> &'static str {
+        use self::MaliciousServerErrorType::*;
+        match *self {
+            InvalidRnonce => "The server returned an invalid rnonce during authentication",
+            InvalidServerSignature => "The server returned an invalid signature during authentication",
+            NoServerSignature => "The server did not sign its reponse during authentication",
+        }
+    }
+}
+
 impl fmt::Display for MaliciousServerErrorType {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            MaliciousServerErrorType::InvalidRnonce => {
-                fmt.write_str(
-                    "The server returned an invalid rnonce during authentication",
-                )
-            }
-            MaliciousServerErrorType::InvalidServerSignature => {
-                fmt.write_str(
-                    "The server returned an invalid signature during authentication",
-                )
-            }
-            MaliciousServerErrorType::NoServerSignature => {
-                fmt.write_str("The server did not sign its reponse during authentication")
-            }
-        }
+        fmt.write_str(self.to_str())
     }
 }
 
@@ -91,7 +88,7 @@ impl<'a> From<&'a str> for Error {
 
 impl From<String> for Error {
     fn from(s: String) -> Error {
-        Error::DefaultError(String::from(s))
+        Error::DefaultError(s)
     }
 }
 
@@ -156,10 +153,8 @@ impl fmt::Display for Error {
             Error::ArgumentError(ref inner) => inner.fmt(fmt),
             Error::OperationError(ref inner) => inner.fmt(fmt),
             Error::ResponseError(ref inner) => inner.fmt(fmt),
-            Error::CursorNotFoundError => write!(fmt, "No cursor found for cursor operation."),
-            Error::PoisonLockError => {
-                write!(fmt, "Socket lock poisoned while attempting to access.")
-            }
+            Error::CursorNotFoundError => fmt.write_str("No cursor found for cursor operation."),
+            Error::PoisonLockError => fmt.write_str("Socket lock poisoned while attempting to access."),
             Error::CodedError(ref err) => write!(fmt, "{}", err),
             Error::EventListenerError(ref err) => {
                 match *err {
@@ -170,7 +165,7 @@ impl fmt::Display for Error {
                             e
                         )
                     }
-                    None => write!(fmt, "Unable to emit failure due to poisoned lock"),
+                    None => fmt.write_str("Unable to emit failure due to poisoned lock"),
                 }
             }
             Error::MaliciousServerError(ref err) => write!(fmt, "{}", err),
@@ -198,19 +193,7 @@ impl error::Error for Error {
                     None => "Due to a poisoned lock on the listeners, unable to emit event",
                 }
             }
-            Error::MaliciousServerError(ref err) => {
-                match *err {
-                    MaliciousServerErrorType::InvalidRnonce => {
-                        "The server returned an invalid rnonce during authentication"
-                    }
-                    MaliciousServerErrorType::InvalidServerSignature => {
-                        "The server returned an invalid signature during authentication"
-                    }
-                    MaliciousServerErrorType::NoServerSignature => {
-                        "The server did not sign its reponse during authentication"
-                    }
-                }
-            }
+            Error::MaliciousServerError(err) => err.to_str(),
             Error::ArgumentError(ref inner) |
             Error::OperationError(ref inner) |
             Error::ResponseError(ref inner) |
@@ -241,7 +224,7 @@ impl error::Error for Error {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ErrorCode {
     OK = 0,
     InternalError = 1,
@@ -416,7 +399,7 @@ impl ErrorCode {
             *self == ErrorCode::IndexAlreadyExists
     }
 
-    fn to_str(&self) -> &str {
+    fn to_str(&self) -> &'static str {
         match *self {
             ErrorCode::OK => "OK",
             ErrorCode::InternalError => "InternalError",

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,7 +21,7 @@ impl MaliciousServerErrorType {
         match *self {
             InvalidRnonce => "The server returned an invalid rnonce during authentication",
             InvalidServerSignature => "The server returned an invalid signature during authentication",
-            NoServerSignature => "The server did not sign its reponse during authentication",
+            NoServerSignature => "The server did not sign its response during authentication",
         }
     }
 }

--- a/src/gridfs/file.rs
+++ b/src/gridfs/file.rs
@@ -23,7 +23,7 @@ pub const DEFAULT_CHUNK_SIZE: i32 = 255 * 1024;
 pub const MEGABYTE: usize = 1024 * 1024;
 
 /// File modes.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Mode {
     Closed,
     Read,
@@ -31,11 +31,13 @@ pub enum Mode {
 }
 
 // Helper class to implement a threaded mutable error.
+#[derive(Debug)]
 struct InnerError {
     inner: Option<Error>,
 }
 
 /// A writable or readable file stream within GridFS.
+#[derive(Debug)]
 pub struct File {
     // The file lock.
     mutex: Arc<Mutex<()>>,
@@ -66,6 +68,7 @@ pub struct File {
 }
 
 /// A one-to-one representation of a file document within GridFS.
+#[derive(Debug)]
 pub struct GfsFile {
     // The byte length.
     len: i64,
@@ -87,13 +90,14 @@ pub struct GfsFile {
     pub metadata: Option<Vec<u8>>,
 }
 
-// A pre-loaded chunk.
+/// A pre-loaded chunk.
+#[derive(Debug)]
 struct CachedChunk {
-    // The file chunk index.
+    /// The file chunk index.
     n: i32,
-    // The binary chunk data.
+    /// The binary chunk data.
     data: Vec<u8>,
-    // The error that occurred during reading, if any occurred.
+    /// The error that occurred during reading, if any occurred.
     err: Option<Error>,
 }
 
@@ -158,7 +162,7 @@ impl File {
 
     /// Retrieves the description of the threaded error, if one occurred.
     pub fn err_description(&self) -> Result<Option<String>> {
-        let err = try!(self.err.read());
+        let err = self.err.read()?;
         let inner = &err.deref().inner;
         let description = match *inner {
             Some(ref err) => Some(String::from(err.description())),
@@ -169,14 +173,16 @@ impl File {
 
     /// Ensures the file mode matches the desired mode.
     pub fn assert_mode(&self, mode: Mode) -> Result<()> {
-        if self.mode != mode {
-            return match self.mode {
-                Mode::Read => Err(ArgumentError(String::from("File is open for reading."))),
-                Mode::Write => Err(ArgumentError(String::from("File is open for writing."))),
-                Mode::Closed => Err(ArgumentError(String::from("File is closed."))),
+        if self.mode == mode {
+            Ok(())
+        } else {
+            let message = match self.mode {
+                Mode::Read => "File is open for reading.",
+                Mode::Write => "File is open for writing.",
+                Mode::Closed => "File is closed.",
             };
+            Err(ArgumentError(String::from(message)))
         }
-        Ok(())
     }
 
     /// Completes writing or reading and closes the file. This will be called when the
@@ -186,37 +192,38 @@ impl File {
 
         // Flush chunks
         if self.mode == Mode::Write {
-            try!(self.flush());
+            self.flush()?;
         }
 
-        let _ = try!(self.mutex.lock());
+        // XXX: Shouldn't this be `_variable`? Binding to `_` drops the value immediately...
+        let _ = self.mutex.lock()?;
 
         // Complete file write
         if self.mode == Mode::Write {
-            if try!(self.err_description()).is_none() {
+            if self.err_description()?.is_none() {
                 if self.doc.upload_date.is_none() {
                     self.doc.upload_date = Some(Utc::now());
                 }
                 self.doc.md5 = hex::encode(self.wsum.result());
-                try!(self.gfs.files.insert_one(self.doc.to_bson(), None));
+                self.gfs.files.insert_one(self.doc.to_bson(), None)?;
 
                 // Ensure indexes
-                try!(self.gfs.files.create_index(doc!{ "filename": 1 }, None));
+                self.gfs.files.create_index(doc!{ "filename": 1 }, None)?;
 
                 let mut opts = IndexOptions::new();
                 opts.unique = Some(true);
-                try!(self.gfs.chunks.create_index(
+                self.gfs.chunks.create_index(
                     doc! {
                         "files_id": 1,
                         "n": 1,
                     },
                     Some(opts),
-                ));
+                )?;
             } else {
-                try!(self.gfs.chunks.delete_many(
+                self.gfs.chunks.delete_many(
                     doc! { "files_id": self.doc.id.clone() },
                     None,
-                ));
+                )?;
             }
         }
 
@@ -224,14 +231,15 @@ impl File {
         if self.mode == Mode::Read && self.rcache.is_some() {
             {
                 let cache = self.rcache.as_ref().unwrap();
-                let _ = try!(cache.lock());
+                // XXX: what's the point in an immediately-dropped lock guard?
+                let _ = cache.lock()?;
             }
             self.rcache = None;
         }
 
         self.mode = Mode::Closed;
 
-        let description = try!(self.err_description());
+        let description = self.err_description()?;
         if description.is_some() {
             Err(OperationError(description.unwrap()))
         } else {
@@ -247,9 +255,8 @@ impl File {
         let mut vec_buf = Vec::with_capacity(buf.len());
         vec_buf.extend(buf.iter().cloned());
 
-        let document =
-            doc! {
-            "_id": try!(oid::ObjectId::new()),
+        let document = doc! {
+            "_id": oid::ObjectId::new()?,
             "files_id": self.doc.id.clone(),
             "n": n,
             "data": (BinarySubtype::Generic, vec_buf)
@@ -266,6 +273,7 @@ impl File {
             let result = arc_gfs.chunks.insert_one(document, None);
 
             // Complete pending write
+            // XXX: shouldn't this be `_variable` too? Assigning to `_` drops the guard immediately.
             let _ = arc_mutex.lock();
             arc_wpending.fetch_sub(1, Ordering::SeqCst);
             if result.is_err() {
@@ -286,7 +294,7 @@ impl File {
             "n": chunk_num,
         };
 
-        match try!(self.gfs.chunks.find_one(Some(filter), None)) {
+        match self.gfs.chunks.find_one(Some(filter), None)? {
             Some(doc) => {
                 match doc.get("data") {
                     Some(&Bson::Binary(_, ref buf)) => Ok(buf.clone()),
@@ -304,14 +312,14 @@ impl File {
 
         // Find the file chunk from the cache or from GridFS.
         let data = if let Some(lock) = self.rcache.take() {
-            let cache = try!(lock.lock());
+            let cache = lock.lock()?;
             if cache.n == curr_chunk_num && cache.err.is_none() {
                 cache.data.clone()
             } else {
-                try!(self.find_chunk(id, curr_chunk_num))
+                self.find_chunk(id, curr_chunk_num)?
             }
         } else {
-            try!(self.find_chunk(id, curr_chunk_num))
+            self.find_chunk(id, curr_chunk_num)?
         };
 
         self.chunk_num += 1;
@@ -371,14 +379,14 @@ impl File {
 
 impl io::Write for File {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        try!(self.assert_mode(Mode::Write));
+        self.assert_mode(Mode::Write)?;
 
         let mut guard = match self.mutex.lock() {
             Ok(guard) => guard,
             Err(_) => return Err(io::Error::new(io::ErrorKind::Other, PoisonLockError)),
         };
 
-        let description = try!(self.err_description());
+        let description = self.err_description()?;
         if description.is_some() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -422,7 +430,7 @@ impl io::Write for File {
                     Err(_) => return Err(io::Error::new(io::ErrorKind::Other, PoisonLockError)),
                 };
 
-                let description = try!(self.err_description());
+                let description = self.err_description()?;
                 if description.is_some() {
                     return Err(io::Error::new(
                         io::ErrorKind::Other,
@@ -433,7 +441,7 @@ impl io::Write for File {
 
             // Flush chunk to GridFS
             let chunk = self.wbuf.clone();
-            try!(self.insert_chunk(curr_chunk_num, &chunk));
+            self.insert_chunk(curr_chunk_num, &chunk)?;
             self.wbuf.clear();
         }
 
@@ -455,7 +463,7 @@ impl io::Write for File {
                     Err(_) => return Err(io::Error::new(io::ErrorKind::Other, PoisonLockError)),
                 };
 
-                let description = try!(self.err_description());
+                let description = self.err_description()?;
                 if description.is_some() {
                     return Err(io::Error::new(
                         io::ErrorKind::Other,
@@ -464,7 +472,7 @@ impl io::Write for File {
                 }
             }
 
-            try!(self.insert_chunk(curr_chunk_num, part1));
+            self.insert_chunk(curr_chunk_num, part1)?;
             data = part2;
         }
 
@@ -474,7 +482,7 @@ impl io::Write for File {
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        try!(self.assert_mode(Mode::Write));
+        self.assert_mode(Mode::Write)?;
 
         let mut guard = match self.mutex.lock() {
             Ok(guard) => guard,
@@ -482,7 +490,7 @@ impl io::Write for File {
         };
 
         // Flush local buffer to GridFS
-        if !self.wbuf.is_empty() && try!(self.err_description()).is_none() {
+        if !self.wbuf.is_empty() && self.err_description()?.is_none() {
             let chunk_num = self.chunk_num;
             self.chunk_num += 1;
             self.wsum.input(&self.wbuf);
@@ -498,9 +506,9 @@ impl io::Write for File {
             }
 
             // Flush and clear local buffer.
-            if try!(self.err_description()).is_none() {
+            if self.err_description()?.is_none() {
                 let chunk = self.wbuf.clone();
-                try!(self.insert_chunk(chunk_num, &chunk));
+                self.insert_chunk(chunk_num, &chunk)?;
                 self.wbuf.clear();
             }
         }
@@ -513,7 +521,7 @@ impl io::Write for File {
             }
         }
 
-        let description = try!(self.err_description());
+        let description = self.err_description()?;
         if description.is_some() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -527,7 +535,7 @@ impl io::Write for File {
 
 impl io::Read for File {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        try!(self.assert_mode(Mode::Read));
+        self.assert_mode(Mode::Read)?;
 
         let _ = match self.mutex.lock() {
             Ok(guard) => guard,
@@ -541,12 +549,12 @@ impl io::Read for File {
 
         // Read all required chunks into memory
         while self.rbuf.len() < buf.len() {
-            let chunk = try!(self.get_chunk());
+            let chunk = self.get_chunk()?;
             self.rbuf.extend(chunk);
         }
 
         // Write into buf
-        let i = try!((&mut *buf).write(&self.rbuf));
+        let i = (&mut *buf).write(&self.rbuf)?;
         self.offset += i as i64;
 
         // Save unread chunk portion into local read buffer
@@ -616,16 +624,16 @@ impl GfsFile {
             file.name = Some(name.to_owned());
         }
 
-        if let Some(&Bson::I32(ref chunk_size)) = doc.get("chunkSize") {
-            file.chunk_size = *chunk_size;
+        if let Some(&Bson::I32(chunk_size)) = doc.get("chunkSize") {
+            file.chunk_size = chunk_size;
         }
 
-        if let Some(&Bson::UtcDatetime(ref datetime)) = doc.get("uploadDate") {
-            file.upload_date = Some(*datetime);
+        if let Some(&Bson::UtcDatetime(datetime)) = doc.get("uploadDate") {
+            file.upload_date = Some(datetime);
         }
 
-        if let Some(&Bson::I64(ref length)) = doc.get("length") {
-            file.len = *length;
+        if let Some(&Bson::I64(length)) = doc.get("length") {
+            file.len = length;
         }
 
         if let Some(&Bson::String(ref hash)) = doc.get("md5") {
@@ -645,8 +653,7 @@ impl GfsFile {
 
     /// Converts a GfsFile into a bson document.
     pub fn to_bson(&self) -> bson::Document {
-        let mut doc =
-            doc! {
+        let mut doc = doc! {
             "_id": self.id.clone(),
             "chunkSize": self.chunk_size,
             "length": self.len,
@@ -654,28 +661,16 @@ impl GfsFile {
             "uploadDate": self.upload_date.as_ref().unwrap().clone()
         };
 
-        if self.name.is_some() {
-            doc.insert(
-                "filename",
-                Bson::String(self.name.as_ref().unwrap().to_owned()),
-            );
+        if let Some(name) = self.name.as_ref() {
+            doc.insert("filename", name);
         }
 
-        if self.content_type.is_some() {
-            doc.insert(
-                "contentType",
-                Bson::String(self.content_type.as_ref().unwrap().to_owned()),
-            );
+        if let Some(content_type) = self.content_type.as_ref() {
+            doc.insert("contentType", content_type);
         }
 
-        if self.metadata.is_some() {
-            doc.insert(
-                "metadata",
-                Bson::Binary(
-                    BinarySubtype::Generic,
-                    self.metadata.as_ref().unwrap().clone(),
-                ),
-            );
+        if let Some(metadata) = self.metadata.as_ref() {
+            doc.insert("metadata", (BinarySubtype::Generic, metadata.clone()));
         }
 
         doc

--- a/src/gridfs/file.rs
+++ b/src/gridfs/file.rs
@@ -230,7 +230,6 @@ impl File {
         if self.mode == Mode::Read && self.rcache.is_some() {
             {
                 let cache = self.rcache.as_ref().unwrap();
-                // XXX: what's the point in an immediately-dropped lock guard?
                 let _ = cache.lock()?;
             }
             self.rcache = None;

--- a/src/gridfs/file.rs
+++ b/src/gridfs/file.rs
@@ -195,8 +195,7 @@ impl File {
             self.flush()?;
         }
 
-        // XXX: Shouldn't this be `_variable`? Binding to `_` drops the value immediately...
-        let _ = self.mutex.lock()?;
+        let _guard = self.mutex.lock()?;
 
         // Complete file write
         if self.mode == Mode::Write {
@@ -273,9 +272,10 @@ impl File {
             let result = arc_gfs.chunks.insert_one(document, None);
 
             // Complete pending write
-            // XXX: shouldn't this be `_variable` too? Assigning to `_` drops the guard immediately.
-            let _ = arc_mutex.lock();
+            let _guard = arc_mutex.lock();
+
             arc_wpending.fetch_sub(1, Ordering::SeqCst);
+
             if result.is_err() {
                 if let Ok(mut err_mut) = err.write() {
                     err_mut.inner = Some(result.err().unwrap());

--- a/src/gridfs/mod.rs
+++ b/src/gridfs/mod.rs
@@ -45,6 +45,7 @@ use std::{io, fs};
 use std::sync::Arc;
 
 /// A default cursor wrapper that maps bson documents into GridFS file representations.
+#[derive(Debug)]
 pub struct FileCursor {
     store: Store,
     cursor: Cursor,
@@ -69,21 +70,21 @@ impl Iterator for FileCursor {
 impl FileCursor {
     /// Returns the next n files.
     pub fn next_n(&mut self, n: i32) -> Result<Vec<File>> {
-        let docs = try!(self.cursor.next_n(n));
+        let docs = self.cursor.next_n(n)?;
         Ok(
             docs.into_iter()
                 .map(|doc| File::with_doc(self.store.clone(), doc.clone()))
-                .collect(),
+                .collect()
         )
     }
 
     /// Returns the next batch of files.
     pub fn drain_current_batch(&mut self) -> Result<Vec<File>> {
-        let docs = try!(self.cursor.drain_current_batch());
+        let docs = self.cursor.drain_current_batch()?;
         Ok(
             docs.into_iter()
                 .map(|doc| File::with_doc(self.store.clone(), doc))
-                .collect(),
+                .collect()
         )
     }
 }
@@ -92,6 +93,7 @@ impl FileCursor {
 pub type Store = Arc<StoreInner>;
 
 /// Interfaces with a GridFS instance.
+#[derive(Debug)]
 pub struct StoreInner {
     files: Collection,
     chunks: Collection,
@@ -131,8 +133,8 @@ impl ThreadedStore for Store {
 
     fn with_prefix(db: Database, prefix: String) -> Store {
         Arc::new(StoreInner {
-            files: db.collection(&format!("{}.files", prefix)[..]),
-            chunks: db.collection(&format!("{}.chunks", prefix)[..]),
+            files: db.collection(&format!("{}.files", prefix)),
+            chunks: db.collection(&format!("{}.chunks", prefix)),
         })
     }
 
@@ -140,7 +142,7 @@ impl ThreadedStore for Store {
         Ok(File::with_name(
             self.clone(),
             name,
-            try!(oid::ObjectId::new()),
+            oid::ObjectId::new()?,
             Mode::Write,
         ))
     }
@@ -149,17 +151,17 @@ impl ThreadedStore for Store {
         let mut options = FindOptions::new();
         options.sort = Some(doc!{ "uploadDate": 1 });
 
-        match try!(self.files.find_one(
+        match self.files.find_one(
             Some(doc!{ "filename": name }),
             Some(options),
-        )) {
+        )? {
             Some(bdoc) => Ok(File::with_doc(self.clone(), bdoc)),
             None => Err(ArgumentError(String::from("File does not exist."))),
         }
     }
 
     fn open_id(&self, id: oid::ObjectId) -> Result<File> {
-        match try!(self.files.find_one(Some(doc!{ "_id": id }), None)) {
+        match self.files.find_one(Some(doc!{ "_id": id }), None)? {
             Some(bdoc) => Ok(File::with_doc(self.clone(), bdoc)),
             None => Err(ArgumentError(String::from("File does not exist."))),
         }
@@ -172,7 +174,7 @@ impl ThreadedStore for Store {
     ) -> Result<FileCursor> {
         Ok(FileCursor {
             store: self.clone(),
-            cursor: try!(self.files.find(filter, options)),
+            cursor: self.files.find(filter, options)?,
             err: None,
         })
     }
@@ -181,36 +183,36 @@ impl ThreadedStore for Store {
         let mut options = FindOptions::new();
         options.projection = Some(doc!{ "_id": 1 });
 
-        let cursor = try!(self.find(Some(doc!{ "filename": name }), Some(options)));
+        let cursor = self.find(Some(doc!{ "filename": name }), Some(options))?;
         for doc in cursor {
-            try!(self.remove_id(doc.id.clone()));
+            self.remove_id(doc.id.clone())?;
         }
 
         Ok(())
     }
 
     fn remove_id(&self, id: oid::ObjectId) -> Result<()> {
-        try!(self.files.delete_many(doc!{ "_id": id.clone() }, None));
-        try!(self.chunks.delete_many(
+        self.files.delete_many(doc!{ "_id": id.clone() }, None)?;
+        self.chunks.delete_many(
             doc!{ "files_id": id.clone() },
             None,
-        ));
+        )?;
         Ok(())
     }
 
     fn put(&self, name: String) -> Result<()> {
-        let mut file = try!(self.create(name.clone()));
-        let mut f = try!(fs::File::open(name));
-        try!(io::copy(&mut f, &mut file));
-        try!(file.close());
+        let mut file = self.create(name.clone())?;
+        let mut f = fs::File::open(name)?;
+        io::copy(&mut f, &mut file)?;
+        file.close()?;
         Ok(())
     }
 
     fn get(&self, name: String) -> Result<()> {
-        let mut f = try!(fs::File::create(name.clone()));
-        let mut file = try!(self.open(name));
-        try!(io::copy(&mut file, &mut f));
-        try!(file.close());
+        let mut f = fs::File::create(name.clone())?;
+        let mut file = self.open(name)?;
+        io::copy(&mut file, &mut f)?;
+        file.close()?;
         Ok(())
     }
 }

--- a/src/gridfs/mod.rs
+++ b/src/gridfs/mod.rs
@@ -69,7 +69,7 @@ impl Iterator for FileCursor {
 
 impl FileCursor {
     /// Returns the next n files.
-    pub fn next_n(&mut self, n: i32) -> Result<Vec<File>> {
+    pub fn next_n(&mut self, n: usize) -> Result<Vec<File>> {
         let docs = self.cursor.next_n(n)?;
         Ok(
             docs.into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,12 +341,12 @@ impl ThreadedClient for Client {
     }
 
     fn with_uri(uri: &str) -> Result<Client> {
-        let config = try!(connstring::parse(uri));
+        let config = connstring::parse(uri)?;
         Client::with_config(config, None, None)
     }
 
     fn with_uri_and_options(uri: &str, options: ClientOptions) -> Result<Client> {
-        let config = try!(connstring::parse(uri));
+        let config = connstring::parse(uri)?;
         Client::with_config(config, Some(options), None)
     }
 
@@ -370,24 +370,24 @@ impl ThreadedClient for Client {
             Some(string) => {
                 let _ = listener.add_start_hook(log_command_started);
                 let _ = listener.add_completion_hook(log_command_completed);
-                Some(Mutex::new(try!(
+                Some(Mutex::new(
                     OpenOptions::new()
                         .write(true)
                         .append(true)
                         .create(true)
-                        .open(&string)
-                )))
+                        .open(&string)?
+                ))
             }
             None => None,
         };
 
         let client = Arc::new(ClientInner {
             req_id: Arc::new(ATOMIC_ISIZE_INIT),
-            topology: try!(Topology::new(
+            topology: Topology::new(
                 config.clone(),
                 description,
                 client_options.stream_connector.clone(),
-            )),
+            )?,
             listener: listener,
             read_preference: rp,
             write_concern: wc,
@@ -397,12 +397,12 @@ impl ThreadedClient for Client {
         // Fill servers array and set options
         {
             let top_description = &client.topology.description;
-            let mut top = try!(top_description.write());
+            let mut top = top_description.write()?;
             top.heartbeat_frequency_ms = client_options.heartbeat_frequency_ms;
             top.server_selection_timeout_ms = client_options.server_selection_timeout_ms;
             top.local_threshold_ms = client_options.local_threshold_ms;
 
-            for host in &config.hosts {
+            for host in config.hosts {
                 let server = Server::new(
                     client.clone(),
                     host.clone(),
@@ -411,7 +411,7 @@ impl ThreadedClient for Client {
                     client_options.stream_connector.clone(),
                 );
 
-                top.servers.insert(host.clone(), server);
+                top.servers.insert(host, server);
             }
         }
 
@@ -447,11 +447,10 @@ impl ThreadedClient for Client {
     }
 
     fn database_names(&self) -> Result<Vec<String>> {
-        let mut doc = bson::Document::new();
-        doc.insert("listDatabases", Bson::I32(1));
-
+        let doc = doc!{ "listDatabases": 1 };
         let db = self.db("admin");
-        let res = try!(db.command(doc, CommandType::ListDatabases, None));
+        let res = db.command(doc, CommandType::ListDatabases, None)?;
+
         if let Some(&Bson::Array(ref batch)) = res.get("databases") {
             // Extract database names
             let map = batch
@@ -465,26 +464,23 @@ impl ThreadedClient for Client {
                     None
                 })
                 .collect();
-            return Ok(map);
-        }
 
-        Err(ResponseError(
-            String::from("Server reply does not contain 'databases'."),
-        ))
+            Ok(map)
+        } else {
+            Err(ResponseError(
+                String::from("Server reply does not contain 'databases'."),
+            ))
+        }
     }
 
     fn drop_database(&self, db_name: &str) -> Result<()> {
-        let db = self.db(db_name);
-        try!(db.drop_database());
-        Ok(())
+        self.db(db_name).drop_database()
     }
 
     fn is_master(&self) -> Result<bool> {
-        let mut doc = bson::Document::new();
-        doc.insert("isMaster", Bson::I32(1));
-
+        let doc = doc!{ "isMaster": 1 };
         let db = self.db("local");
-        let res = try!(db.command(doc, CommandType::IsMaster, None));
+        let res = db.command(doc, CommandType::IsMaster, None)?;
 
         match res.get("ismaster") {
             Some(&Bson::Boolean(is_master)) => Ok(is_master),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,7 @@ pub use apm::{CommandStarted, CommandResult};
 pub use command_type::CommandType;
 pub use error::{Error, ErrorCode, Result};
 
+use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::ops::DerefMut;
@@ -198,6 +199,19 @@ pub struct ClientInner {
     topology: Topology,
     listener: Listener,
     log_file: Option<Mutex<File>>,
+}
+
+impl fmt::Debug for ClientInner {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ClientInner")
+            .field("read_preference", &self.read_preference)
+            .field("write_concern", &self.write_concern)
+            .field("req_id", &self.req_id)
+            .field("topology", &"Topology { .. }")
+            .field("listener", &"Listener { .. }")
+            .field("log_file", &self.log_file)
+            .finish()
+    }
 }
 
 /// Configuration options for a client.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ impl fmt::Debug for ClientInner {
             .field("read_preference", &self.read_preference)
             .field("write_concern", &self.write_concern)
             .field("req_id", &self.req_id)
-            .field("topology", &"Topology { .. }")
+            .field("topology", &self.topology)
             .field("listener", &"Listener { .. }")
             .field("log_file", &self.log_file)
             .finish()

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -11,6 +11,8 @@ use stream::{Stream, StreamConnector};
 use wire_protocol::flags::OpQueryFlags;
 
 use bufstream::BufStream;
+
+use std::fmt;
 use std::sync::{Arc, Condvar, Mutex};
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 
@@ -27,6 +29,14 @@ pub struct ConnectionPool {
     // to be repopulated with available connections.
     wait_lock: Arc<Condvar>,
     stream_connector: StreamConnector,
+}
+
+impl fmt::Debug for ConnectionPool {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ConnectionPool")
+            .field("host", &self.host)
+            .finish()
+    }
 }
 
 struct Pool {

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -15,6 +15,7 @@ use stream::StreamConnector;
 use rand::{thread_rng, Rng};
 
 use std::collections::HashMap;
+use std::fmt;
 use std::i64;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
@@ -67,8 +68,26 @@ pub struct TopologyDescription {
     stream_connector: StreamConnector,
 }
 
+impl fmt::Debug for TopologyDescription {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("TopologyDescription")
+            .field("topology_type", &self.topology_type)
+            .field("set_name", &self.set_name)
+            .field("servers", &"HashMap<Host, Server> { .. }")
+            .field("heartbeat_frequency_ms", &self.heartbeat_frequency_ms)
+            .field("local_threshold_ms", &self.local_threshold_ms)
+            .field("server_selection_timeout_ms", &self.server_selection_timeout_ms)
+            .field("max_election_id", &self.max_election_id)
+            .field("compatible", &self.compatible)
+            .field("max_set_version", &self.max_set_version)
+            .field("compat_error", &self.compat_error)
+            .field("stream_connector", &"StreamConnector { .. }")
+            .finish()
+    }
+}
+
 /// Holds status and connection information about a server set.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Topology {
     /// The initial connection configuration.
     pub config: ConnectionString,
@@ -78,6 +97,7 @@ pub struct Topology {
 
 impl FromStr for TopologyType {
     type Err = Error;
+
     fn from_str(s: &str) -> Result<Self> {
         Ok(match s {
             "Single" => TopologyType::Single,
@@ -109,10 +129,8 @@ impl Default for TopologyDescription {
 
 impl TopologyDescription {
     /// Returns a default, unknown topology description.
-    pub fn new(connector: StreamConnector) -> TopologyDescription {
-        let mut description = TopologyDescription::default();
-        description.stream_connector = connector;
-        description
+    pub fn new(stream_connector: StreamConnector) -> TopologyDescription {
+        TopologyDescription { stream_connector, ..Default::default() }
     }
 
     /// Returns the nearest server stream, calculated by round trip time.
@@ -135,7 +153,7 @@ impl TopologyDescription {
         });
 
         // Iterate over each host until one's stream can be acquired.
-        for host in servers.iter() {
+        for host in servers {
             if let Some(server) = self.servers.get(host) {
                 if let Ok(description) = server.description.read() {
                     if description.round_trip_time.is_none() {
@@ -189,8 +207,10 @@ impl TopologyDescription {
         // Special case - If secondaries are found, by are filtered out by tag sets,
         // the topology should return any available primaries instead.
         if hosts.is_empty() && read_preference.mode == ReadMode::SecondaryPreferred {
-            let mut read_pref = read_preference.clone();
-            read_pref.mode = ReadMode::PrimaryPreferred;
+            let read_pref = ReadPreference {
+                mode: ReadMode::PrimaryPreferred,
+                ..read_preference.clone()
+            };
             return self.acquire_stream(client, &read_pref);
         }
 
@@ -206,9 +226,9 @@ impl TopologyDescription {
 
         // Retrieve a server stream from the list of acceptable hosts.
         let (pooled_stream, server_type) = if rand {
-            try!(self.get_rand_from_vec(client, &mut hosts))
+            self.get_rand_from_vec(client, &mut hosts)?
         } else {
-            try!(self.get_nearest_from_vec(client, &mut hosts))
+            self.get_nearest_from_vec(client, &mut hosts)?
         };
 
         // Determine how to handle server-side logic based on ReadMode and TopologyType.
@@ -263,9 +283,9 @@ impl TopologyDescription {
         }
 
         if rand {
-            Ok(try!(self.get_rand_from_vec(client, &mut hosts)).0)
+            Ok(self.get_rand_from_vec(client, &mut hosts)?.0)
         } else {
-            Ok(try!(self.get_nearest_from_vec(client, &mut hosts)).0)
+            Ok(self.get_nearest_from_vec(client, &mut hosts)?.0)
         }
     }
 
@@ -279,14 +299,14 @@ impl TopologyDescription {
 
         // Set the tag_filter to the first tag set that matches at least one server in the set.
         for tags in &read_preference.tag_sets {
-            for host in hosts.iter() {
+            for host in &*hosts {
                 if let Some(server) = self.servers.get(host) {
                     let description = server.description.read().unwrap();
 
                     // Check whether the read preference tags are contained
                     // within the server description tags.
                     let mut valid = true;
-                    for (key, val) in tags.iter() {
+                    for (key, val) in tags {
                         match description.tags.get(key) {
                             Some(v) => {
                                 if val != v {
@@ -342,7 +362,7 @@ impl TopologyDescription {
                         let description = server.description.read().unwrap();
 
                         // Validate tag sets.
-                        for (key, val) in tag_filter.iter() {
+                        for (key, val) in tag_filter {
                             match description.tags.get(key) {
                                 Some(v) => {
                                     if val != v {
@@ -855,8 +875,7 @@ impl Topology {
 
         if config.hosts.len() > 1 && options.topology_type == TopologyType::Single {
             return Err(ArgumentError(String::from(
-                "TopologyType::Single cannot be used with \
-                                                   multiple seeds.",
+                "TopologyType::Single cannot be used with multiple seeds.",
             )));
         }
 
@@ -871,8 +890,7 @@ impl Topology {
             options.topology_type != TopologyType::ReplicaSetNoPrimary
         {
             return Err(ArgumentError(String::from(
-                "TopologyType must be ReplicaSetNoPrimary if \
-                                                   set_name is provided.",
+                "TopologyType must be ReplicaSetNoPrimary if  set_name is provided.",
             )));
         }
 
@@ -937,7 +955,7 @@ impl Topology {
 
     /// Returns a server stream for write operations.
     pub fn acquire_write_stream(&self, client: Client) -> Result<PooledStream> {
-        let (stream, _, _) = try!(self.acquire_stream_private(client, None, true));
+        let (stream, _, _) = self.acquire_stream_private(client, None, true)?;
         Ok(stream)
     }
 }

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -890,7 +890,7 @@ impl Topology {
             options.topology_type != TopologyType::ReplicaSetNoPrimary
         {
             return Err(ArgumentError(String::from(
-                "TopologyType must be ReplicaSetNoPrimary if  set_name is provided.",
+                "TopologyType must be ReplicaSetNoPrimary if set_name is provided.",
             )));
         }
 

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -29,7 +29,7 @@ pub const DEFAULT_LOCAL_THRESHOLD_MS: i64 = 15;
 pub const DEFAULT_SERVER_SELECTION_TIMEOUT_MS: i64 = 30000;
 
 /// Describes the type of topology for a server set.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum TopologyType {
     Single,
     ReplicaSetNoPrimary,

--- a/src/topology/server.rs
+++ b/src/topology/server.rs
@@ -23,7 +23,7 @@ use super::TopologyDescription;
 pub const ROUND_TRIP_DIVISOR: i64 = 5;
 
 /// Describes the server role within a server set.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ServerType {
     /// Standalone server.
     Standalone,
@@ -43,8 +43,14 @@ pub enum ServerType {
     Unknown,
 }
 
+impl Default for ServerType {
+    fn default() -> Self {
+        ServerType::Unknown
+    }
+}
+
 /// Server information gathered from server monitoring.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ServerDescription {
     /// The server type.
     pub server_type: ServerType,
@@ -77,7 +83,7 @@ pub struct ServerDescription {
 }
 
 /// Holds status and connection information about a single server.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Server {
     /// Host connection details.
     pub host: Host,
@@ -91,6 +97,7 @@ pub struct Server {
 
 impl FromStr for ServerType {
     type Err = Error;
+
     fn from_str(s: &str) -> Result<Self> {
         Ok(match s {
             "Standalone" => ServerType::Standalone,
@@ -105,31 +112,10 @@ impl FromStr for ServerType {
     }
 }
 
-impl Default for ServerDescription {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl ServerDescription {
     /// Returns a default, unknown server description.
     pub fn new() -> ServerDescription {
-        ServerDescription {
-            server_type: ServerType::Unknown,
-            err: Arc::new(None),
-            round_trip_time: None,
-            min_wire_version: 0,
-            max_wire_version: 0,
-            me: None,
-            hosts: Vec::new(),
-            passives: Vec::new(),
-            arbiters: Vec::new(),
-            tags: BTreeMap::new(),
-            set_name: String::new(),
-            election_id: None,
-            primary: None,
-            set_version: None,
-        }
+        Default::default()
     }
 
     // Updates the server description using an isMaster server response.

--- a/src/wire_protocol/flags.rs
+++ b/src/wire_protocol/flags.rs
@@ -51,6 +51,7 @@ impl OpQueryFlags {
     /// Returns the newly created OpQueryFlags struct.
     pub fn with_find_options(options: &FindOptions) -> OpQueryFlags {
         let mut flags = OpQueryFlags::empty();
+
         if options.cursor_type != CursorType::NonTailable {
             flags.insert(Self::TAILABLE_CURSOR);
         }

--- a/src/wire_protocol/mod.rs
+++ b/src/wire_protocol/mod.rs
@@ -1,4 +1,5 @@
 //! Low-level client-server communication over the MongoDB wire protocol.
+
 mod header;
 pub mod flags;
 pub mod operations;


### PR DESCRIPTION
Hey there!

First off, thanks for making a MongoDB driver for Rust!

This PR cleans up and modernizes the code somewhat, improving its efficiency, interoperability, and style. In particular, the following modifications have been made. These, I believe, do not alter either the API or the modus operandi of the library.

* Remove many unnecessary mutations, allocations and copies, especially around constructing BSON documents and default-able types, often via the struct update syntax (e.g. `let mut foo = Foo::default(); foo.bar = baz;` -> `let foo = Foo { bar: baz, ..Foo::default() };`
* Replace complicated control flow around optionals and results with standard library methods
* Rewrite several mutating raw for loops using `Iterator` methods
* `#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)`] or at least as many of them as possible and makes sense for several public-facing types.
* Replace remaining uses of `try!()` with `?`
* Replace check-and-force with pattern matching, e.g. `if vec.len() == 1 { &vec[0] }` -> `if let Some(…) = vec.get(0)`, or `if opt.is_some() { opt.unwrap().do_stuff() }` -> `if let Some(val) = opt { val.do_stuff() }`
* Rewrite unneeded macro invocations using functions (e.g. `vec![]` -> `Vec::new()`, `doc!{}` -> `Document::new()`)
* Eliminate some closures using beta-reduction, e.g. `map(|foo| foo.to_bson())` -> `map(Foo::to_bson)`
* Simplify some unnecessarily complex code in general

Furthermore, I have identified and marked with `XXX` a few potential issues regarding lock guards. I have not actually modified the corresponding code because I might be misunderstanding it, however I think it would be valuable to discuss this issue separately.
