### PR TITLE
Basic authorizated connection function.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,6 +282,8 @@ pub trait ThreadedClient: Sync + Sized {
     fn connect(host: &str, port: u16) -> Result<Self>;
     /// Creates a new Client directly connected to a single MongoDB server with options.
     fn connect_with_options(host: &str, port: u16, ClientOptions) -> Result<Self>;
+    /// Connect with authorizations
+    fn auth_connect(host: &str, port: u16, dbname: &str, uname: &str, pword: &str) -> Result<Client>;
     /// Creates a new Client connected to a complex topology, such as a
     /// replica set or sharded cluster.
     fn with_uri(uri: &str) -> Result<Self>;
@@ -327,9 +329,30 @@ pub type Client = Arc<ClientInner>;
 impl ThreadedClient for Client {
     fn connect(host: &str, port: u16) -> Result<Client> {
         let config = ConnectionString::new(host, port);
+        
         let mut description = TopologyDescription::new(StreamConnector::Tcp);
         description.topology_type = TopologyType::Single;
         Client::with_config(config, None, Some(description))
+    }
+
+    fn auth_connect(host: &str, port: u16, dbname: &str, uname: &str, pword: &str) -> Result<Client> {
+        let mut config = ConnectionString::new(host, port);
+
+        config.user = Some(uname.to_string());
+        config.password = Some(pword.to_string());
+
+        let mut description = TopologyDescription::new(StreamConnector::Tcp);
+        description.topology_type = TopologyType::Single;
+        
+        let client = Client::with_config(config, None, Some(description)).unwrap();
+
+        let _ = match client.db(dbname).auth(uname, pword) {
+            Ok(_) => true,
+            Err(_) => panic!("Error with authentication"),
+        };
+
+        Ok(client)
+
     }
 
     fn connect_with_options(host: &str, port: u16, options: ClientOptions) -> Result<Client> {


### PR DESCRIPTION
I implemented a separate connection function specifically for connecting with authorization to help curb the effects of #205. This doesn't authenticate everything in the connection pool as you mentioned, but it connects right when the function is called. 

I included an image below of the execution of #205 using the updated function I wrote

<img width="660" alt="screen shot 2018-09-15 at 6 09 01 pm" src="https://user-images.githubusercontent.com/15281447/45591020-6fbde300-b914-11e8-89b4-029d46758bbd.png">

This is no way a finished function, I just wanted to get feedback to see if I was headed in the right direction with this. Thank you!