### PR TITLE
Implement support for read concerns

### DIFF
--- a/script/start_mongo_release
+++ b/script/start_mongo_release
@@ -16,9 +16,17 @@ if [ ! -d "$install_dir/$release" ]; then
 fi
 
 # Start mongod processes
+enable_read_concern=""
+if [[ "$release" == *"3.2."* ]]; then
+  enable_read_concern="--enableMajorityReadConcern"
+fi
+if [[ "$release" == *"3.4."* ]]; then
+  enable_read_concern="--enableMajorityReadConcern"
+fi
+
 data="$install_dir/data/$release"
 data_ssl="$data-ssl"
 
 mkdir -p $data $data_ssl
-$install_dir/$release/bin/mongod --fork --dbpath $data --syslog --port 27017
-$install_dir/$release/bin/mongod --fork --dbpath $data_ssl --syslog --port 27018 --sslMode requireSSL --sslPEMKeyFile tests/ssl/server.pem --sslCAFile tests/ssl/ca.pem --sslAllowConnectionsWithoutCertificates
+$install_dir/$release/bin/mongod --fork $enable_read_concern --dbpath $data --syslog --port 27017
+$install_dir/$release/bin/mongod --fork $enable_read_concern --dbpath $data_ssl --syslog --port 27018 --sslMode requireSSL --sslPEMKeyFile tests/ssl/server.pem --sslCAFile tests/ssl/ca.pem --sslAllowConnectionsWithoutCertificates

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -1,6 +1,6 @@
 //! Options for collection-level operations.
 use bson::{self, Bson};
-use common::{ReadPreference, WriteConcern};
+use common::{ReadConcern, ReadPreference, WriteConcern};
 use Error::ArgumentError;
 use Result;
 
@@ -64,6 +64,7 @@ pub struct AggregateOptions {
     pub use_cursor: Option<bool>,
     pub batch_size: i32,
     pub max_time_ms: Option<i64>,
+    pub read_concern: Option<ReadConcern>,
     pub read_preference: Option<ReadPreference>,
 }
 
@@ -87,7 +88,13 @@ impl From<AggregateOptions> for bson::Document {
         let cursor = doc! { "batchSize": options.batch_size };
         document.insert("cursor", cursor);
 
-        // maxTimeMS is not currently used by the driver.
+        if let Some(max_time_ms) = options.max_time_ms {
+            document.insert("maxTimeMS", max_time_ms);
+        }
+
+        if let Some(read_concern) = options.read_concern {
+            document.insert("readConcern", read_concern.to_document());
+        }
 
         // read_preference is used directly by Collection::aggregate.
 
@@ -103,6 +110,7 @@ pub struct CountOptions {
     pub hint: Option<String>,
     pub hint_doc: Option<bson::Document>,
     pub max_time_ms: Option<i64>,
+    pub read_concern: Option<ReadConcern>,
     pub read_preference: Option<ReadPreference>,
 }
 
@@ -132,7 +140,13 @@ impl From<CountOptions> for bson::Document {
             document.insert("hint_doc", hint_doc);
         }
 
-        // maxTimeMS is not currently used by the driver.
+        if let Some(max_time_ms) = options.max_time_ms {
+            document.insert("maxTimeMS", max_time_ms);
+        }
+
+        if let Some(read_concern) = options.read_concern {
+            document.insert("readConcern", read_concern.to_document());
+        }
 
         // read_preference is used directly by Collection::count.
 
@@ -144,6 +158,7 @@ impl From<CountOptions> for bson::Document {
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DistinctOptions {
     pub max_time_ms: Option<i64>,
+    pub read_concern: Option<ReadConcern>,
     pub read_preference: Option<ReadPreference>,
 }
 
@@ -168,6 +183,7 @@ pub struct FindOptions {
     pub modifiers: Option<bson::Document>,
     pub projection: Option<bson::Document>,
     pub sort: Option<bson::Document>,
+    pub read_concern: Option<ReadConcern>,
     pub read_preference: Option<ReadPreference>,
 }
 
@@ -185,7 +201,7 @@ impl From<FindOptions> for bson::Document {
         // `allow_partial_results`, `no_cursor_timeout`, `oplog_relay`, and `cursor_type` are used by
         // wire_protocol::OpQueryFlags.
         //
-        // `max_time_ms` and `modifiers` are not currently used by the driver.
+        // `modifiers` are not currently used by the driver.
         //
         // read_preference is used directly by Collection::find_with_command_type.
 
@@ -207,6 +223,14 @@ impl From<FindOptions> for bson::Document {
 
         if let Some(sort) = options.sort {
             document.insert("sort", sort);
+        }
+
+        if let Some(max_time_ms) = options.max_time_ms {
+            document.insert("maxTimeMS", max_time_ms);
+        }
+
+        if let Some(read_concern) = options.read_concern {
+            document.insert("readConcern", read_concern.to_document());
         }
 
         document

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,6 +6,62 @@ use bson::{self, Bson};
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
+/// Level of desired consistency and isolation properties of the data read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ReadConcernLevel {
+    Local,
+    Available,
+    Majority,
+    Linearizable,
+    Snapshot,
+}
+
+impl ReadConcernLevel {
+    fn to_str(&self) -> &'static str {
+        match *self {
+            ReadConcernLevel::Available => "available",
+            ReadConcernLevel::Linearizable => "linearizable",
+            ReadConcernLevel::Local => "local",
+            ReadConcernLevel::Majority => "majority",
+            ReadConcernLevel::Snapshot => "snapshot",
+        }
+    }
+}
+
+impl FromStr for ReadConcernLevel {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self> {
+        Ok(match s {
+            "available" => ReadConcernLevel::Available,
+            "linearizable" => ReadConcernLevel::Linearizable,
+            "local" => ReadConcernLevel::Local,
+            "majority" => ReadConcernLevel::Majority,
+            "snapshot" => ReadConcernLevel::Snapshot,
+            _ => {
+                return Err(ArgumentError(
+                    format!("Could not convert '{}' to ReadConcernLevel.", s),
+                ))
+            }
+        })
+    }
+}
+
+/// Indicates the consistency and isolation properties of the data read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReadConcern {
+    pub level: ReadConcernLevel,
+}
+
+impl ReadConcern {
+    pub fn new(level: ReadConcernLevel) -> ReadConcern {
+        ReadConcern { level }
+    }
+
+    pub fn to_document(&self) -> bson::Document {
+        doc! { "level": self.level.to_str() }
+    }
+}
+
 /// Indicates how a server should be selected during read operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ReadMode {

--- a/tests/client/crud_spec/framework.rs
+++ b/tests/client/crud_spec/framework.rs
@@ -243,9 +243,16 @@ macro_rules! run_update_test {
 #[macro_export]
 macro_rules! run_suite {
     ( $file:expr, $coll:expr ) => {{
+        run_suite_with_options!($file, $coll, ClientOptions::new())
+    }};
+}
+
+#[macro_export]
+macro_rules! run_suite_with_options {
+    ( $file:expr, $coll:expr, $opts:expr ) => {{
         let json = Value::from_file($file).unwrap();
         let suite = json.get_suite().unwrap();
-        let client =  Client::connect("localhost", 27017).unwrap();
+        let client =  Client::connect_with_options("localhost", 27017, $opts).unwrap();
         let db = client.db("test");
         let coll = db.collection($coll);
 

--- a/tests/client/crud_spec/mod.rs
+++ b/tests/client/crud_spec/mod.rs
@@ -1,4 +1,5 @@
 #[macro_use]
 mod framework;
 mod read;
+mod read_concern;
 mod write;

--- a/tests/client/crud_spec/read.rs
+++ b/tests/client/crud_spec/read.rs
@@ -2,7 +2,7 @@ use bson::Bson;
 use json::crud::arguments::Arguments;
 use json::crud::reader::SuiteContainer;
 use json::eq::{self, NumEq};
-use mongodb::{Client, ThreadedClient};
+use mongodb::{Client, ClientOptions, ThreadedClient};
 use mongodb::coll::options::{InsertManyOptions, ReplaceOptions, UpdateOptions};
 use mongodb::db::ThreadedDatabase;
 use serde_json::Value;

--- a/tests/client/crud_spec/read_concern.rs
+++ b/tests/client/crud_spec/read_concern.rs
@@ -1,0 +1,66 @@
+use bson::Bson;
+use json::crud::arguments::Arguments;
+use json::crud::reader::SuiteContainer;
+use json::eq::{self, NumEq};
+use mongodb::{Client, ClientOptions, ThreadedClient};
+use mongodb::coll::options::{InsertManyOptions, ReplaceOptions, UpdateOptions};
+use mongodb::common::{ReadConcern, ReadConcernLevel};
+use mongodb::db::ThreadedDatabase;
+use serde_json::Value;
+
+#[test]
+fn aggregate() {
+    // Skip for MongoDB < 3.2 since it does not support read concerns.
+    let client = Client::connect("localhost", 27017).unwrap();
+    let db = client.db("test-client-db-concern_aggregate");
+    db.drop_database().unwrap();
+    let db_version = db.version().unwrap();
+    if db_version.major <= 3 && db_version.minor < 2 {
+        return;
+    }
+
+    let mut options = ClientOptions::new();
+    options.max_time_ms = Some(2000);
+    options.read_concern = Some(ReadConcern::new(ReadConcernLevel::Majority));
+    run_suite_with_options!(
+        "tests/json/data/specs/source/crud/tests/read/aggregate.json",
+        "concern_aggregate",
+        options
+    );
+}
+
+#[test]
+fn count() {
+    let mut options = ClientOptions::new();
+    options.max_time_ms = Some(2000);
+    options.read_concern = Some(ReadConcern::new(ReadConcernLevel::Majority));
+    run_suite_with_options!(
+        "tests/json/data/specs/source/crud/tests/read/count.json",
+        "concern_count",
+        options
+    );
+}
+
+#[test]
+fn distinct() {
+    let mut options = ClientOptions::new();
+    options.max_time_ms = Some(2000);
+    options.read_concern = Some(ReadConcern::new(ReadConcernLevel::Majority));
+    run_suite_with_options!(
+        "tests/json/data/specs/source/crud/tests/read/distinct.json",
+        "concern_distinct",
+        options
+    );
+}
+
+#[test]
+fn find() {
+    let mut options = ClientOptions::new();
+    options.max_time_ms = Some(2000);
+    options.read_concern = Some(ReadConcern::new(ReadConcernLevel::Majority));
+    run_suite_with_options!(
+        "tests/json/data/specs/source/crud/tests/read/find.json",
+        "concern_find",
+        options
+    );
+}

--- a/tests/client/crud_spec/write.rs
+++ b/tests/client/crud_spec/write.rs
@@ -2,7 +2,7 @@ use bson::Bson;
 use json::crud::arguments::Arguments;
 use json::crud::reader::SuiteContainer;
 use json::eq::{self, NumEq};
-use mongodb::{Client, ThreadedClient};
+use mongodb::{Client, ClientOptions, ThreadedClient};
 use mongodb::coll::options::{InsertManyOptions, ReplaceOptions, UpdateOptions};
 use mongodb::db::ThreadedDatabase;
 use serde_json::Value;


### PR DESCRIPTION
This PR addresses the read concern support part of #278.

**Note**: this PR introduces a breaking change because it requires the default read concern and max time ms attributes to be passed to some methods.