### PR TITLE
fix the implementation of the read function for gridfs/File

### DIFF
--- a/src/gridfs/file.rs
+++ b/src/gridfs/file.rs
@@ -547,7 +547,7 @@ impl io::Read for File {
         }
 
         // Read all required chunks into memory
-        while self.rbuf.len() < buf.len() && (self.chunk_num as i64) * (self.doc.chunk_size as i64) < self.doc.len{
+        while self.rbuf.len() < buf.len() && (self.chunk_num as i64) * (self.doc.chunk_size as i64) < self.doc.len {
             let chunk = self.get_chunk()?;
             self.rbuf.extend(chunk);
         }

--- a/src/gridfs/file.rs
+++ b/src/gridfs/file.rs
@@ -547,7 +547,7 @@ impl io::Read for File {
         }
 
         // Read all required chunks into memory
-        while self.rbuf.len() < buf.len() {
+        while self.rbuf.len() < buf.len() && (self.chunk_num as i64) * (self.doc.chunk_size as i64) < self.doc.len{
             let chunk = self.get_chunk()?;
             self.rbuf.extend(chunk);
         }


### PR DESCRIPTION
This pull request solved a problem for the implementation of the `read` function of the `File` struct in the `gridfs` module.

When the **OperationError(String::from("Chunk not found.")** cache state is set, and the output buffer(buf) is bigger than the read buffer(rbuf), the `get_chunk` function should be called only when there are more than one remaining chunks. Or else, if there isn't any remaining chunk, the `read` and other `read*` functions will return **OperationError(String::from("Chunk not found.")**.