### PR TITLE
Re-export bson lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "mongodb"
 readme = "README.md"
 repository = "https://github.com/mongodb-labs/mongo-rust-driver-prototype"
-version = "0.3.10"
+version = "0.3.11"
 
 [dependencies]
 bitflags = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ The driver is available on crates.io. To use the MongoDB driver in your code, ad
 
 ```toml
 [dependencies]
-bson = "0.12.2"
-mongodb = "0.3.10"
+mongodb = "0.3.11"
 ```
 
 Alternately, you can use the MongoDB driver with SSL support. To do this, you must have OpenSSL installed on your system. Then, enable the `ssl` feature for MongoDB in your Cargo.toml:
@@ -31,15 +30,21 @@ Alternately, you can use the MongoDB driver with SSL support. To do this, you mu
 ```toml
 [dependencies]
 # ...
-mongodb = { version = "0.3.10", features = ["ssl"] }
+mongodb = { version = "0.3.11", features = ["ssl"] }
 ```
 
 Then, import the bson and driver libraries within your code.
 
 ```rust
 #[macro_use(bson, doc)]
-extern crate bson;
 extern crate mongodb;
+```
+
+or with Rust 3.10+:
+
+```rust
+extern crate mongodb;
+use mongodb::{bson, doc};
 ```
 
 Examples
@@ -48,7 +53,7 @@ Examples
 Here's a basic example of driver usage:
 
 ```rust
-use bson::Bson;
+use mongodb::Bson;
 use mongodb::{Client, ThreadedClient};
 use mongodb::db::ThreadedDatabase;
 
@@ -88,7 +93,7 @@ fn main() {
 To connect with SSL, use either `ClientOptions::with_ssl` or `ClientOptions::with_unauthenticated_ssl` and then `Client::connect_with_options`. Afterwards, the client can be used as above (note that the server will have to be configured to accept SSL connections and that you'll have to generate your own keys and certificates):
 
 ```rust
-use bson::Bson;
+use mongodb::Bson;
 use mongodb::{Client, ClientOptions, ThreadedClient};
 use mongodb::db::ThreadedDatabase;
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,6 +1,6 @@
 //! Authentication schemes.
 use bson::Bson::{self, Binary};
-use bson::Document;
+use bson::{Document, bson, doc};
 use bson::spec::BinarySubtype::Generic;
 use CommandType::Suppressed;
 use hmac::{Hmac, Mac};

--- a/src/coll/batch.rs
+++ b/src/coll/batch.rs
@@ -1,7 +1,7 @@
 //! Models for collection-level batch operations.
 use super::options::WriteModel;
 
-use bson::{Bson, Document};
+use bson::{Bson, Document, bson, doc};
 use std::convert::From;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -4,7 +4,7 @@ pub mod error;
 pub mod options;
 pub mod results;
 
-use bson::{self, Bson, oid};
+use bson::{self, Bson, bson, doc, oid};
 use command_type::CommandType;
 
 use self::batch::{Batch, DeleteModel, UpdateModel};

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -1,5 +1,5 @@
 //! Options for collection-level operations.
-use bson::{self, Bson};
+use bson::{self, Bson, bson, doc};
 use common::{ReadPreference, WriteConcern};
 use Error::ArgumentError;
 use Result;

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,7 +2,7 @@
 use Error::{self, ArgumentError};
 use Result;
 
-use bson::{self, Bson};
+use bson::{self, Bson, bson, doc};
 use std::collections::BTreeMap;
 use std::str::FromStr;
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -26,7 +26,7 @@
 use {Client, CommandType, Error, ErrorCode, Result, ThreadedClient};
 use apm::{CommandStarted, CommandResult, EventRunner};
 
-use bson::{self, Bson};
+use bson::{self, bson, doc, Bson};
 use common::{merge_options, ReadMode, ReadPreference};
 use coll::options::FindOptions;
 use pool::PooledStream;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -59,8 +59,7 @@ pub mod options;
 pub mod roles;
 
 use auth::Authenticator;
-use bson;
-use bson::Bson;
+use bson::{self, bson, doc, Bson};
 use {Client, CommandType, ThreadedClient, Result};
 use Error::{CursorNotFoundError, OperationError, ResponseError};
 use coll::Collection;

--- a/src/db/roles.rs
+++ b/src/db/roles.rs
@@ -1,7 +1,7 @@
 //! Role-based database and command authorization.
 use std::string::ToString;
 
-use bson::Bson;
+use bson::{Bson, bson, doc};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SingleDatabaseRole {

--- a/src/gridfs/file.rs
+++ b/src/gridfs/file.rs
@@ -1,5 +1,5 @@
 //! Lower-level file and chunk representations in GridFS.
-use bson::{self, Bson, oid};
+use bson::{self, Bson, bson, doc, oid};
 use bson::spec::BinarySubtype;
 
 use chrono::{DateTime, Utc};

--- a/src/gridfs/mod.rs
+++ b/src/gridfs/mod.rs
@@ -30,7 +30,7 @@
 //! ```
 pub mod file;
 
-use bson::{self, oid};
+use bson::{self, bson, doc, oid};
 
 use db::{Database, ThreadedDatabase};
 use coll::Collection;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,8 @@
 #[doc(html_root_url = "https://docs.rs/mongodb")]
 #[macro_use]
 extern crate bitflags;
-#[macro_use(bson, doc)]
 extern crate bson;
+pub use bson::{bson, doc};
 extern crate bufstream;
 extern crate byteorder;
 extern crate chrono;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,6 @@
 #[macro_use]
 extern crate bitflags;
 extern crate bson;
-pub use bson::{bson, doc};
 extern crate bufstream;
 extern crate byteorder;
 extern crate chrono;
@@ -163,6 +162,8 @@ mod apm;
 mod auth;
 mod command_type;
 
+pub use bson::*;
+
 pub use apm::{CommandStarted, CommandResult};
 pub use command_type::CommandType;
 pub use error::{Error, ErrorCode, Result};
@@ -175,7 +176,6 @@ use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicIsize, Ordering, ATOMIC_ISIZE_INIT};
 
 use apm::Listener;
-use bson::Bson;
 use common::{ReadPreference, ReadMode, WriteConcern};
 use connstring::ConnectionString;
 use db::{Database, ThreadedDatabase};

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -10,6 +10,7 @@ use cursor::Cursor;
 use stream::{Stream, StreamConnector};
 use wire_protocol::flags::OpQueryFlags;
 
+use bson::{bson, doc};
 use bufstream::BufStream;
 
 use std::fmt;

--- a/src/topology/monitor.rs
+++ b/src/topology/monitor.rs
@@ -2,7 +2,7 @@
 use {Client, Result};
 use Error::{self, ArgumentError, OperationError};
 
-use bson::{self, Bson, oid};
+use bson::{self, Bson, bson, doc, oid};
 use chrono::{DateTime, Utc};
 
 use coll::options::FindOptions;


### PR DESCRIPTION
Closes #281.

This converts usage of `macro_use` into explicit imports of `use bson::{bson, doc}`.

Also re-exports bson::* to remove downstream requirements of installing the correct version of bson.

Cut as version 0.3.11.

cc. @H2CO3 