### PR TITLE
Allow SSL configurations to fall back on the system CA

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,7 @@ impl ClientOptions {
     #[cfg(feature = "ssl")]
     /// Creates a new options struct with a specified SSL certificate and key files.
     pub fn with_ssl(
-        ca_file: &str,
+        ca_file: Option<&str>,
         certificate_file: &str,
         key_file: &str,
         verify_peer: bool,
@@ -270,7 +270,7 @@ impl ClientOptions {
 
     #[cfg(feature = "ssl")]
     /// Creates a new options struct with a specified SSL certificate
-    pub fn with_unauthenticated_ssl(ca_file: &str, verify_peer: bool) -> ClientOptions {
+    pub fn with_unauthenticated_ssl(ca_file: Option<&str>, verify_peer: bool) -> ClientOptions {
         let mut options = ClientOptions::new();
         options.stream_connector = StreamConnector::with_unauthenticated_ssl(ca_file, verify_peer);
         options

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -16,7 +16,7 @@ pub enum StreamConnector {
     ///
     /// Note that it's invalid to have one of certificate_file and key_file set but not the other.
     Ssl {
-        ca_file: String,
+        ca_file: Option<String>,
         certificate_file: Option<String>,
         key_file: Option<String>,
         verify_peer: bool,
@@ -50,13 +50,13 @@ impl StreamConnector {
     /// `key_file` - Path to the file containing the client private key.
     /// `verify_peer` - Whether or not to verify that the server's certificate is trusted.
     pub fn with_ssl(
-        ca_file: &str,
+        ca_file: Option<&str>,
         certificate_file: &str,
         key_file: &str,
         verify_peer: bool,
     ) -> Self {
         StreamConnector::Ssl {
-            ca_file: String::from(ca_file),
+            ca_file: ca_file.map(String::from),
             certificate_file: Some(String::from(certificate_file)),
             key_file: Some(String::from(key_file)),
             verify_peer: verify_peer,
@@ -80,9 +80,9 @@ impl StreamConnector {
     ///
     /// `ca_file` - Path to the file containing trusted CA certificates.
     /// `verify_peer` - Whether or not to verify that the server's certificate is trusted.
-    pub fn with_unauthenticated_ssl(ca_file: &str, verify_peer: bool) -> Self {
+    pub fn with_unauthenticated_ssl(ca_file: Option<&str>, verify_peer: bool) -> Self {
         StreamConnector::Ssl {
-            ca_file: String::from(ca_file),
+            ca_file: ca_file.map(String::from),
             certificate_file: None,
             key_file: None,
             verify_peer: verify_peer,
@@ -106,7 +106,10 @@ impl StreamConnector {
                 ssl_context.set_options(SslOptions::NO_SSLV2);
                 ssl_context.set_options(SslOptions::NO_SSLV3);
                 ssl_context.set_options(SslOptions::NO_COMPRESSION);
-                ssl_context.set_ca_file(ca_file)?;
+
+                if let Some(ca_file) = ca_file {
+                    ssl_context.set_ca_file(ca_file)?;
+                }
 
                 if let &Some(ref file) = certificate_file {
                     ssl_context.set_certificate_file(file, SslFiletype::PEM)?;

--- a/tests/ssl/mod.rs
+++ b/tests/ssl/mod.rs
@@ -10,7 +10,7 @@ fn ssl_connect_and_insert() {
     test_path.push("ssl");
 
     let options = ClientOptions::with_ssl(
-        test_path.join("ca.pem").to_str().unwrap(),
+        Some(test_path.join("ca.pem").to_str().unwrap()),
         test_path.join("client.crt").to_str().unwrap(),
         test_path.join("client.key").to_str().unwrap(),
         false,
@@ -30,8 +30,10 @@ fn unauthenticated_ssl_connect_and_insert() {
     test_path.push("tests");
     test_path.push("ssl");
 
-    let options =
-        ClientOptions::with_unauthenticated_ssl(test_path.join("ca.pem").to_str().unwrap(), false);
+    let options = ClientOptions::with_unauthenticated_ssl(
+        Some(test_path.join("ca.pem").to_str().unwrap()),
+        false,
+    );
     let client = Client::connect_with_options("127.0.0.1", 27018, options).unwrap();
     let db = client.db("test");
     let coll = db.collection("stuff");


### PR DESCRIPTION
The current SSL API requires users to specify a certificate authority file. All of the official drivers allow users to instead fallback to the system CA, so we should do that too.

In order to test this properly, we'd need to spin up a third mongod that requires SSL but does not have a CA specified and then make a specific test that attempts to connect without specifying it. Given that this is a very small variation on the existing SSL tests and that we rely entirely on the OpenSSL implementation to perform this feature, I don't think it's worth increasing our Travis usage by 50% for this (especially given that Travis servers are grouped by Github organization/user, and there are a _lot_ of projects in mongodb-labs, some of which have more pressing needs for prompt CI feedback). I've verified that this works locally.