### PR TITLE
A few bug fixes & two convenience items.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ data-encoding = "2.0.0"
 rand = "0.3.15"
 scan_fmt = "0.1.1"
 semver = "0.8.0"
+serde = "1"
+serde_derive = "1"
 separator = "0.3.1"
 time = "0.1.37"
 md-5 = "0.7.0"
@@ -26,7 +28,6 @@ sha-1 = "0.7.0"
 hmac = "0.6.2"
 pbkdf2 = "0.2.0"
 hex = "0.3.2"
-
 
 [dependencies.clippy]
 optional = true
@@ -36,18 +37,16 @@ version = "~0"
 optional = true
 version = "0.10.15"
 
+[dependencies.serde_json]
+version = "1"
+features = ["preserve_order"]
+
 [dependencies.textnonce]
 default-features = false
 version = "0.6.3"
 
 [dev-dependencies]
 approx = "0.1.1"
-serde = "1.0.69"
-serde_derive = "1.0.69"
-
-[dev-dependencies.serde_json]
-features = ["preserve_order"]
-version = "1.0.3"
 
 [features]
 default = []

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -1054,12 +1054,7 @@ impl Collection {
     /// This is the same as `list_indexes`, and still uses a `Cursor` under the hood. The elements
     /// are serialized as `IndexModel`s as they are received.
     pub fn list_index_models(&self) -> Result<impl Iterator<Item=Result<IndexModel>>> {
-        let cmd = doc!{ "listIndexes": self.name() };
-        self.db.command_cursor(
-            cmd,
-            CommandType::ListIndexes,
-            self.read_preference.to_owned(),
-        ).map(|cursor| {
+        self.list_indexes().map(|cursor| {
             cursor.map(|doc_res| {
                 doc_res.and_then(|doc| -> Result<IndexModel> {
                     bson::from_bson(bson::Bson::Document(doc)).map_err(|err| DecoderError(err))

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -18,7 +18,7 @@ use cursor::Cursor;
 use db::{Database, ThreadedDatabase};
 
 use Result;
-use Error::{ArgumentError, ResponseError, OperationError, BulkWriteError};
+use Error::{ArgumentError, DecoderError, ResponseError, OperationError, BulkWriteError};
 
 use wire_protocol::flags::OpQueryFlags;
 use std::collections::{BTreeMap, VecDeque};
@@ -1047,5 +1047,24 @@ impl Collection {
             CommandType::ListIndexes,
             self.read_preference.to_owned(),
         )
+    }
+
+    /// List all indexes in the collection as serialized `IndexModel`s.
+    ///
+    /// This is the same as `list_indexes`, and still uses a `Cursor` under the hood. The elements
+    /// are serialized as `IndexModel`s as they are received.
+    pub fn list_index_models(&self) -> Result<impl Iterator<Item=Result<IndexModel>>> {
+        let cmd = doc!{ "listIndexes": self.name() };
+        self.db.command_cursor(
+            cmd,
+            CommandType::ListIndexes,
+            self.read_preference.to_owned(),
+        ).map(|cursor| {
+            cursor.map(|doc_res| {
+                doc_res.and_then(|doc| -> Result<IndexModel> {
+                    bson::from_bson(bson::Bson::Document(doc)).map_err(|err| DecoderError(err))
+                })
+            })
+        })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,9 @@ extern crate rand;
 #[macro_use]
 extern crate scan_fmt;
 extern crate semver;
+extern crate serde;
+#[macro_use(Serialize, Deserialize)]
+extern crate serde_derive;
 extern crate separator;
 extern crate textnonce;
 extern crate time;


### PR DESCRIPTION
Closes #224
Closes #282
Closes #289

Fixes a bug where `geoHaystack` indexes were being blocked from creation.

Fixes a bug where the `storageEngine` index option had the wrong type.

Implemented a convenience method as discussed in #224. `Cursor` is still
the base iterator type, but the output has been wrapped as an `impl
Iterator` for convenience. Works exactly the same way, but yields
`IndexModel` elements instead of plain old `Document`s.

Added serde derivations to `IndexModel` & (by necessity) `IndexOptions`.
The BSON crate already directly depends on the serde, serde_derive &
serde_json. They've been added to the dependencies section of the
Cargo.toml as they are now direct dependencies of this crate, but this
does not technically add any new deps.

----

### thoughts on semver version to use
- nothing backwards incompatible here. #282 may seem like a backwards incompatibility, but as the server was rejecting any previously given values, I would still consider this to be a patch increment change.
- we could totally do a `0.4` release. No reason not to really. This changeset does add `list_index_models` & serde derivations on `IndexModel`.

Any reason not to do a `0.4`?