### PR TITLE
Removed deprecated ATOMIC_*_INIT usage

### DIFF
--- a/src/gridfs/file.rs
+++ b/src/gridfs/file.rs
@@ -17,7 +17,7 @@ use std::error::Error as ErrorTrait;
 use std::io::Write;
 use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Condvar, Mutex, RwLock};
-use std::sync::atomic::{AtomicIsize, ATOMIC_ISIZE_INIT, Ordering};
+use std::sync::atomic::{AtomicIsize, Ordering};
 
 pub const DEFAULT_CHUNK_SIZE: i32 = 255 * 1024;
 pub const MEGABYTE: usize = 1024 * 1024;
@@ -140,7 +140,7 @@ impl File {
             gfs: gfs,
             chunk_num: 0,
             offset: 0,
-            wpending: Arc::new(ATOMIC_ISIZE_INIT),
+            wpending: Arc::new(AtomicIsize::new(0)),
             wbuf: Vec::new(),
             wsum: Md5::new(),
             rbuf: Vec::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex};
-use std::sync::atomic::{AtomicIsize, Ordering, ATOMIC_ISIZE_INIT};
+use std::sync::atomic::{AtomicIsize, Ordering};
 
 use apm::Listener;
 use common::{ReadPreference, ReadMode, WriteConcern};
@@ -385,7 +385,7 @@ impl ThreadedClient for Client {
         };
 
         let client = Arc::new(ClientInner {
-            req_id: Arc::new(ATOMIC_ISIZE_INIT),
+            req_id: Arc::new(AtomicIsize::new(0)),
             topology: Topology::new(
                 config.clone(),
                 description,

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -15,7 +15,7 @@ use bufstream::BufStream;
 
 use std::fmt;
 use std::sync::{Arc, Condvar, Mutex};
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub static DEFAULT_POOL_SIZE: usize = 5;
 
@@ -106,7 +106,7 @@ impl ConnectionPool {
             host: host,
             wait_lock: Arc::new(Condvar::new()),
             inner: Arc::new(Mutex::new(Pool {
-                len: Arc::new(ATOMIC_USIZE_INIT),
+                len: Arc::new(AtomicUsize::new(0)),
                 size: size,
                 sockets: Vec::with_capacity(size),
                 iteration: 0,


### PR DESCRIPTION
ATOMIC_ISIZE_INIT and ATOMIC_USIZE_INIT were deprecated in 1.34.0.  This patch updates to recommended usage.