### PR TITLE
Added dyn keyword for trait objects

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -201,7 +201,7 @@ impl error::Error for Error {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::WriteError(ref inner) => Some(inner),
             Error::BulkWriteError(ref inner) => Some(inner),

--- a/src/wire_protocol/header.rs
+++ b/src/wire_protocol/header.rs
@@ -115,7 +115,7 @@ impl Header {
     /// # Return value
     ///
     /// Returns nothing on success, or an Error on failure.
-    pub fn write(&self, buffer: &mut Write) -> Result<()> {
+    pub fn write(&self, buffer: &mut dyn Write) -> Result<()> {
         buffer.write_i32::<LittleEndian>(self.message_length)?;
         buffer.write_i32::<LittleEndian>(self.request_id)?;
         buffer.write_i32::<LittleEndian>(self.response_to)?;
@@ -134,7 +134,7 @@ impl Header {
     /// # Return value
     ///
     /// Returns the parsed Header on success, or an Error on failure.
-    pub fn read(buffer: &mut Read) -> Result<Header> {
+    pub fn read(buffer: &mut dyn Read) -> Result<Header> {
         let message_length = buffer.read_i32::<LittleEndian>()?;
         let request_id = buffer.read_i32::<LittleEndian>()?;
         let response_to = buffer.read_i32::<LittleEndian>()?;

--- a/src/wire_protocol/header.rs
+++ b/src/wire_protocol/header.rs
@@ -115,7 +115,7 @@ impl Header {
     /// # Return value
     ///
     /// Returns nothing on success, or an Error on failure.
-    pub fn write(&self, buffer: &mut dyn Write) -> Result<()> {
+    pub fn write<W: Write>(&self, buffer: &mut W) -> Result<()> {
         buffer.write_i32::<LittleEndian>(self.message_length)?;
         buffer.write_i32::<LittleEndian>(self.request_id)?;
         buffer.write_i32::<LittleEndian>(self.response_to)?;
@@ -134,7 +134,7 @@ impl Header {
     /// # Return value
     ///
     /// Returns the parsed Header on success, or an Error on failure.
-    pub fn read(buffer: &mut dyn Read) -> Result<Header> {
+    pub fn read<R: Read>(buffer: &mut R) -> Result<Header> {
         let message_length = buffer.read_i32::<LittleEndian>()?;
         let request_id = buffer.read_i32::<LittleEndian>()?;
         let response_to = buffer.read_i32::<LittleEndian>()?;


### PR DESCRIPTION
'dyn <trait>' syntax introduced in Rust 1.27 for trait objects. Updated to use recommended syntax.