### PR TITLE
Update clippy.toml to work with recent versions of clippy

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-cyclomatic-complexity-threshold = 30
+cognitive-complexity-threshold = 30

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 cognitive-complexity-threshold = 30
+


### PR DESCRIPTION
Without this, running cargo clippy on a crate that depends on `mongodb = "0.3.12"` fails with:

```
error: error reading Clippy's configuration file `/home/cdyer/.cargo/registry/src/github.com-1ecc6299db9ec823/mongodb-0.3.12/clippy.toml`: found deprecated field `cyclomatic-complexity-threshold`. Please use `cognitive-complexity-threshold` instead.

error: aborting due to previous error

error: Could not compile `mongodb`.
```

(Running rust 1.37)
