### PR TITLE
Allow openssl-sys vendoring for static musl builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ version = "~0"
 optional = true
 version = "0.10.15"
 
+[dependencies.openssl-sys]
+optional = true
+version = "*"
+
 [dependencies.serde_json]
 version = "1"
 features = ["preserve_order"]
@@ -51,4 +55,7 @@ approx = "0.1.1"
 [features]
 default = []
 ssl = ["openssl"]
+# Force openssl-sys to staticly link in the openssl library. Necessary when
+# cross compiling to x86_64-unknown-linux-musl.
+vendored = ["openssl-sys/vendored"]
 lint = ["clippy"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,5 +57,5 @@ default = []
 ssl = ["openssl"]
 # Force openssl-sys to staticly link in the openssl library. Necessary when
 # cross compiling to x86_64-unknown-linux-musl.
-vendored = ["openssl-sys/vendored"]
+ssl-vendored = ["ssl", "openssl-sys/vendored"]
 lint = ["clippy"]


### PR DESCRIPTION
This change allows the user to take advantage of the vendor feature included in the openssl-sys crate that openssl depends on. The vendor feature helps when using musl to statically build the mongodb driver with openssl. When users include the "vendor" feature while using the mongodb "ssl" feature, they may use the rust build container from docker hub without also needing to compile the openssl library before starting their cargo build/install process.

An example Dockerfile would be as follows:

> FROM rust:1.37.0
> WORKDIR /usr/src
> 
> _#_ Download the target for static linking.
> RUN apt-get update \\
>   && DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates musl-dev musl-tools make automake \\
>   && update-ca-certificates \\
>   && rustup target add x86_64-unknown-linux-musl \\
>   && mkdir /usr/src/\<project>
> 
> WORKDIR /usr/src/\<project>
> COPY Cargo.* ./
> COPY src ./src
> RUN cargo install --target x86_64-unknown-linux-musl --path .