### PR TITLE
Fix/bind interface

### DIFF
--- a/tests/apm/mod.rs
+++ b/tests/apm/mod.rs
@@ -176,10 +176,9 @@ fn logging() {
     // Third insert started
     line.clear();
     read_first_non_monitor_line(&mut file, &mut line);
-    assert!(
+    assert!(coerce_ip_v6_to_v4(&line).starts_with(
         "COMMAND.insert_one 127.0.0.1:27017 STARTED: { insert: \"logging\", documents: [{ _id: 3 }] }\n",
-        coerce_ip_v6_to_v4(&line)
-    );
+    ));
 
     // Third insert completed
     line.clear();

--- a/tests/apm/mod.rs
+++ b/tests/apm/mod.rs
@@ -232,17 +232,3 @@ fn logging() {
 
     fs::remove_file("test_log.txt").unwrap();
 }
-
-fn assert_with_ip(expected_line: &str, line: &str) {
-    if line.contains("127.0.0.1") {
-        assert_eq!(
-            "COMMAND.create_collection 127.0.0.1:27017 STARTED: { create: \"logging\" }\n",
-            line
-        );
-    } else {
-        assert_eq!(
-            "COMMAND.create_collection qqqq:27017 STARTED: { create: \"logging\" }\n",
-            line
-        );
-    }
-}


### PR DESCRIPTION
In test all assertions check the network interface too.
If your mongo binds `0.0.0.0` (for example using docker) all tests fails.
This PR fixes that.